### PR TITLE
Fix for rabbit_maas hostname

### DIFF
--- a/rpc_deployment/playbooks/monitoring/maas_local.yml
+++ b/rpc_deployment/playbooks/monitoring/maas_local.yml
@@ -136,7 +136,7 @@
 - hosts: rabbit
   vars:
     check_name: rabbitmq_status
-    check_details: file={{ check_name }}.py,args=-H,args={{ ansible_ssh_host }},args=-n,args={{ ansible_hostname }}
+    check_details: file={{ check_name }}.py,args=-H,args={{ ansible_ssh_host }},args=-n,args={{ inventory_hostname.split('.')[0] }}
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:


### PR DESCRIPTION
Since rabbit shortens the FQDN, and we adjust the rabbit play to account
for this, we need to adjust the maas_local play to account for this change.
- Adjust the variables passed to the rabbit maas script to use the short
  name only.

Fixes #383
