### PR TITLE
Setup SSH Keys for the nova users on compute hosts

### DIFF
--- a/rpc_deployment/playbooks/openstack/nova-compute.yml
+++ b/rpc_deployment/playbooks/openstack/nova-compute.yml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- hosts: nova_compute[0]
+  user: root
+  roles:
+    - nova_compute_sshkey_create
+
 - hosts: nova_compute
   user: root
   roles:
@@ -28,6 +33,7 @@
     - nova_libvirt
     - galera_client_cnf
     - init_script
+    - nova_compute_sshkey_setup
   vars_files:
     - inventory/group_vars/nova_all.yml
     - vars/config_vars/container_config_nova_compute.yml

--- a/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
+++ b/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create the nova SSH key if it doesnt exist
+  shell: >
+    ls ~/.ssh/nova 2>/dev/null || ssh-keygen -f ~/.ssh/nova -t rsa -q -N ""
+  delegate_to: localhost

--- a/rpc_deployment/roles/nova_compute_sshkey_setup/files/ssh_config
+++ b/rpc_deployment/roles/nova_compute_sshkey_setup/files/ssh_config
@@ -1,0 +1,2 @@
+Host *
+    StrictHostKeyChecking no

--- a/rpc_deployment/roles/nova_compute_sshkey_setup/tasks/main.yml
+++ b/rpc_deployment/roles/nova_compute_sshkey_setup/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create the keys directory for the nova user
+  file: >
+    state=directory
+    path=/var/lib/nova/.ssh
+    group=nova
+    owner=nova
+    mode=0700
+
+- name: Set nova users shell to /bin/bash and generate ssh_key
+  user: >
+    name=nova
+    shell=/bin/bash
+
+- name: Copy private key up to nova nodes
+  copy: >
+    src="~/.ssh/nova"
+    dest=/var/lib/nova/.ssh/id_rsa
+    owner=nova
+    group=nova
+    mode=0600
+
+- name: Copy public key up to nova nodes
+  copy: >
+    src="~/.ssh/nova.pub"
+    dest=/var/lib/nova/.ssh/id_rsa.pub
+    owner=nova
+    group=nova
+    mode=0644
+
+- name: Add key to authorized_keys file
+  authorized_key:
+    user=nova
+    path=/var/lib/nova/.ssh/authorized_keys
+    manage_dir=no
+    key="{{ lookup('file', '/var/lib/nova/.ssh/id_rsa.pub') }}"
+
+- name: Prevent known_hosts from causing an issue
+  copy: >
+    src=ssh_config
+    dest="/var/lib/nova/.ssh/config"
+    owner=nova
+    group=nova
+    mode=0644
+
+
+


### PR DESCRIPTION
This is required for migrations and resizes to work
- Creates the nova .ssh directory
- Sets up SSH private and public Keys
- Adds public key to authorized_keys file
- Sets StrictHostChecking=no for the nova user

Fixes #5
Fixes #6
