### PR TITLE
HAProxy Client / Server Timeouts for Spice Console

### DIFF
--- a/rpc_deployment/roles/haproxy_service/templates/service
+++ b/rpc_deployment/roles/haproxy_service/templates/service
@@ -11,6 +11,10 @@ bind {{ item.service.hap_bind|default('*') }}:{{ item.service.hap_port }}
     {% set request_option = "tcp" %}
 {% endif %}
 
+{% if item.service.hap_timeout_client is defined %}
+    timeout client {{ item.service.hap_timeout_client }}
+{% endif %}
+
 {% if item.service.hap_whitelist_hosts is defined and item.service.hap_whitelist_hosts == true %}
     acl white_list src 127.0.0.1/8 {{ container_cidr }} {% for host_name in groups['hosts'] %} {{ hostvars[host_name]['ansible_ssh_host'] }} {% endfor %}
 
@@ -34,6 +38,9 @@ backend {{ item.service.hap_service_name }}-back
 {% for option in item.service.hap_backend_options|default([]) %}
     option {{ option }}
 {% endfor %}
+{% if item.service.hap_timeout_server is defined %}
+    timeout server {{ item.service.hap_timeout_server }}
+{% endif %}
 {% for host_name in item.service.hap_backend_nodes %}
     server {{ hostvars[host_name]['container_name']|default(host_name) }} {{ hostvars[host_name]['ansible_ssh_host'] }}:{{ hap_backend_port }} check port {{ hap_backend_port }} inter {{ hap_interval }} rise {{ item.service.hap_backend_nodes|count }} fall {{ item.service.hap_backend_nodes|count }}
 {% endfor %}

--- a/rpc_deployment/vars/config_vars/haproxy_config.yml
+++ b/rpc_deployment/vars/config_vars/haproxy_config.yml
@@ -81,6 +81,8 @@ haproxy_config:
       hap_backend_nodes: "{{ groups['nova_spice_console'] }}"
       hap_port: 6082
       hap_balance_type: http
+      hap_timeout_client: 60m
+      hap_timeout_server: 60m
   - service:
       hap_service_name: cinder_api
       hap_backend_nodes: "{{ groups['cinder_api'] }}"


### PR DESCRIPTION
Spice Console experiences a timeout after about 1 minute when using HAProxy. This adds options for `timeout client` and `timeout server` with a default value of `60m`.
