### PR TITLE
Fix hosts file entries - remove duplicates/stale entries

### DIFF
--- a/rpc_deployment/roles/host_common/tasks/updatehostsfile.yml
+++ b/rpc_deployment/roles/host_common/tasks/updatehostsfile.yml
@@ -13,6 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Update hosts file remove stale IP entries
+  lineinfile:
+    dest: /etc/hosts
+    regexp: "^{{ hostvars[item]['ansible_ssh_host'] }} (?!{{ item }}$)"
+    state: absent
+  with_items:
+    - "{{ groups['all_containers'] }}"
+    - "{{ groups['hosts'] }}"
+
+- name: Update hosts file remove stale Host entries
+  lineinfile:
+    dest: /etc/hosts
+    regexp: "(?<!^{{ hostvars[item]['ansible_ssh_host'] }}) {{ item }}$"
+    state: absent
+  with_items:
+    - "{{ groups['all_containers'] }}"
+    - "{{ groups['hosts'] }}"
+
 - name: Update hosts file from ansible inventory
   lineinfile:
     dest: /etc/hosts


### PR DESCRIPTION
Adds to tasks in the updatehostsfile play that will do the following to the
/etc/hosts file:
- Removes any entries that match the IP of current host, but with a different
  hostname
- Removes any entries that match the hostname of the current host but with a
  different IP

This will prevent duplicate entries and other /etc/hosts file related
strangeness.

Fixes #13
