### PR TITLE
Fix /etc/hosts issues on rabbit servers when using FQDN

### DIFF
--- a/rpc_deployment/roles/rabbit_common/tasks/main.yml
+++ b/rpc_deployment/roles/rabbit_common/tasks/main.yml
@@ -31,6 +31,16 @@
     - package_install
     - rabbit_install
 
+- name: Fix /etc/hosts
+  lineinfile:
+    dest: /etc/hosts
+    state: present
+    line: "{{ hostvars[item]['container_address'] }} {{ hostvars[item]['container_name'] }} {{ hostvars[item]['container_name'].split('.')[0] }}"
+  with_items: groups['rabbit']
+  tags:
+    - hosts
+    - rabbit_config
+
 - name: Install rabbit packages
   apt:
     pkg: "{{ item }}"
@@ -42,16 +52,6 @@
   tags:
     - package_install
     - rabbit_install
-
-- name: Fix /etc/hosts
-  lineinfile:
-    dest: /etc/hosts
-    state: present
-    line: "{{ hostvars[item]['container_address'] }} {{ hostvars[item]['container_name'] }} {{ hostvars[item]['container_name'].split('.')[0] }}"
-  with_items: groups['rabbit']
-  tags:
-    - hosts
-    - rabbit_config
 
 - include: restart_rabbit.yml
 


### PR DESCRIPTION
Rabbit occassionally fails to start because it can't resolve its "short
name"

The /etc/hosts file is dropped after the install phase, which starts up
rabbit automatically - Moving the /etc/hosts file correction to happen
before the install phase will resolve this.

Fixes #39
