### PR TITLE
Adjust timeout for Initial Network Check

### DIFF
--- a/rpc_deployment/roles/container_restart/tasks/main.yml
+++ b/rpc_deployment/roles/container_restart/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Test Container Networking
   wait_for: >
     port=22
-    timeout=60
+    timeout=10
     search_regex=OpenSSH
     host={{ hostvars[item]['container_address'] }}
   with_items: container_groups


### PR DESCRIPTION
The initial network check is used to detemrine whether the containers
need to be restarted or not. On initial setup they need a restart to get
the networking to work.

60 seconds makes the initial run a lot longer than it needs to be,
setting this much lower (10 seconds) will save time.

Fixes #38
