### PR TITLE
Add guards around creation/removal of snet hosts entry

### DIFF
--- a/rpc_deployment/roles/glance_snet_override/tasks/main.yml
+++ b/rpc_deployment/roles/glance_snet_override/tasks/main.yml
@@ -4,10 +4,10 @@
     dest: /etc/hosts
     regexp: "{{ cf_snet_endpoints[glance_swift_store_region]['hostname'] }}"
     line: "{{ cf_snet_endpoints[glance_swift_store_region]['ip'] }} {{ cf_snet_endpoints[glance_swift_store_region]['hostname'] }}"
-  when: glance_swift_enable_snet
+  when: glance_default_store == "swift" and glance_swift_enable_snet and glance_swift_store_region in cf_snet_endpoints
 - name: Remove hosts entry if glance_swift_enable_snet is False
   lineinfile:
     dest: /etc/hosts
     regexp: "{{ cf_snet_endpoints[glance_swift_store_region]['hostname'] }}"
     state: absent
-  when: not glance_swift_enable_snet
+  when: glance_default_store == "swift" and not glance_swift_enable_snet and glance_swift_store_region in cf_snet_endpoints


### PR DESCRIPTION
Currently, the tasks in glance_snet_override are applied even when
glance_default_store is not set to 'swift'.  This minor change
updates the when condition so that we only add/remove the snet hosts
entry when glance_default_store == 'swift' AND when we have a key for
glance_swift_store_region in cf_snet_endpoints.

This addresses the immediate issue in https://github.com/rcbops/ansible-lxc-rpc/issues/32.
