### PR TITLE
Add memcached_servers to [DEFAULT]

### DIFF
--- a/rpc_deployment/roles/nova_common/templates/nova.conf
+++ b/rpc_deployment/roles/nova_common/templates/nova.conf
@@ -79,6 +79,9 @@ allow_resize_to_same_host = False
 # Fix for regression pr-376
 max_age = {{ nova_max_age }}
 
+# Required by consoleauth
+memcached_servers = {{ internal_vip_address }}:{{ memcached_port }}
+
 {% if nova_html5proxy_base_url is defined%}
 [spice]
 agent_enabled = {{ nova_console_agent_enabled|default('True') }}


### PR DESCRIPTION
In nova.conf, we specify memcached_servers but under the
[keystone_authtoken] section.  Since we run multiple nova-consoleauth
processes we need to utilise memcached, and this means adding an
entry for memcached_servers under [DEFAULT].

Addresses https://github.com/rcbops/ansible-lxc-rpc/issues/52.
