### PR TITLE
Set the default ENDPOINT TYPE to internalURL for Horizon

### DIFF
--- a/rpc_deployment/roles/horizon_common/templates/local_settings.py
+++ b/rpc_deployment/roles/horizon_common/templates/local_settings.py
@@ -223,7 +223,7 @@ IMAGE_CUSTOM_PROPERTY_TITLES = {
 # OPENSTACK_ENDPOINT_TYPE specifies the endpoint type to use for the endpoints
 # in the Keystone service catalog. Use this setting when Horizon is running
 # external to the OpenStack environment. The default is 'publicURL'.
-#OPENSTACK_ENDPOINT_TYPE = "publicURL"
+OPENSTACK_ENDPOINT_TYPE = " {{ horizon_endpoint_type }} "
 
 # SECONDARY_ENDPOINT_TYPE specifies the fallback endpoint type to use in the
 # case that OPENSTACK_ENDPOINT_TYPE is not present in the endpoints

--- a/rpc_deployment/vars/openstack_service_vars/horizon.yml
+++ b/rpc_deployment/vars/openstack_service_vars/horizon.yml
@@ -13,29 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: horizon_all
-  user: root
-  roles:
-    - common
-    - container_common
-    - galera_client_cnf
+# The variables file used by the playbooks in the nova-api-ec2 group.
+# These don't have to be explicitly imported by vars_files: they are autopopulated.
 
-- hosts: horizon_all
-  user: root
-  roles:
-    - openstack_common
-    - openstack_openrc
-    - horizon_common
-  vars_files:
-    - vars/openstack_service_vars/horizon.yml
-
-- hosts: horizon_all[0]
-  user: root
-  roles:
-    - galera_db_setup
-    - horizon_setup
-
-- hosts: horizon_all
-  user: root
-  roles:
-    - horizon_apache
+horizon_endpoint_type: internalURL


### PR DESCRIPTION
Default is publicURL which will fail if internal server doesn't have
access via the firewall.

All this value to be overridden via the "horizon" service vars.

Fixes #57
