### PR TITLE
Fix for issue #59

### DIFF
--- a/rpc_deployment/ansible.cfg
+++ b/rpc_deployment/ansible.cfg
@@ -3,6 +3,10 @@ gathering = smart
 hostfile = inventory
 host_key_checking = False
 
+# Setting forks should be based on your system. The ansible defaults to 5, 
+# the ansible-rpc-lxc assumes that you have a system that can support 
+# openstack, thus it has been conservitivly been set to 25
+forks = 25
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
Sets the default ansible forks value to 25. This addresses issue #59 .
