### PR TITLE
Fix container_group var for container playbooks

### DIFF
--- a/rpc_deployment/playbooks/setup/build-containers.yml
+++ b/rpc_deployment/playbooks/setup/build-containers.yml
@@ -18,7 +18,7 @@
   roles:
     - container_create
   vars:
-    default_container_groups: "{{ groups[hostvars[inventory_hostname]['container_types']] }}"
-    container_groups: "{{ groups[container_group]|default(default_container_groups) }}"
+    default_container_groups: "{{ hostvars[inventory_hostname]['container_types'] }}"
+    container_groups: "{{ groups[container_group|default(default_container_groups)] }}"
 
 - include: containers-setup.yml

--- a/rpc_deployment/playbooks/setup/containers-setup.yml
+++ b/rpc_deployment/playbooks/setup/containers-setup.yml
@@ -20,8 +20,8 @@
   vars_files:
     - vars/config_vars/container_interfaces.yml
   vars:
-    default_container_groups: "{{ groups[hostvars[inventory_hostname]['container_types']] }}"
-    container_groups: "{{ groups[container_group]|default(default_container_groups) }}"
+    default_container_groups: "{{ hostvars[inventory_hostname]['container_types'] }}"
+    container_groups: "{{ groups[container_group|default(default_container_groups)] }}"
     required_container_config_options:
       - "lxc.mount.entry=/openstack/log/{{ hostvars[item]['container_name'] }} var/log/{{ hostvars[item]['service_name'] }} none defaults,bind,rw 0 0"
       - "lxc.mount.entry=/openstack/monitoring monitoring none defaults,bind,rw 0 0"

--- a/rpc_deployment/playbooks/setup/destroy-containers.yml
+++ b/rpc_deployment/playbooks/setup/destroy-containers.yml
@@ -19,5 +19,5 @@
   roles:
     - container_destroy
   vars:
-    default_container_groups: "{{ groups[hostvars[inventory_hostname]['container_types']] }}"
-    container_groups: "{{ groups[container_group]|default(default_container_groups) }}"
+    default_container_groups: "{{ hostvars[inventory_hostname]['container_types'] }}"
+    container_groups: "{{ groups[container_group|default(default_container_groups)] }}"

--- a/rpc_deployment/playbooks/setup/restart-containers.yml
+++ b/rpc_deployment/playbooks/setup/restart-containers.yml
@@ -19,5 +19,5 @@
   roles:
     - container_restart
   vars:
-    default_container_groups: "{{ groups[hostvars[inventory_hostname]['container_types']] }}"
-    container_groups: "{{ groups[container_group]|default(default_container_groups) }}"
+    default_container_groups: "{{ hostvars[inventory_hostname]['container_types'] }}"
+    container_groups: "{{ groups[container_group|default(default_container_groups)] }}"


### PR DESCRIPTION
Following on from #61, the container_group has to be specified each
time, this patch fixes that.
- Set the groups for "container_groups" appropriately
