### PR TITLE
hotfix OPENSTACK_ENDPOINT_TYPE type

### DIFF
--- a/rpc_deployment/roles/horizon_common/templates/local_settings.py
+++ b/rpc_deployment/roles/horizon_common/templates/local_settings.py
@@ -2,7 +2,7 @@ import os
 from django.utils.translation import ugettext_lazy as _
 from openstack_dashboard import exceptions
 
-DEBUG = False
+DEBUG = {{ debug|default('False') }}
 TEMPLATE_DEBUG = DEBUG
 COMPRESS_ENABLED = True
 COMPRESS_ROOT = '{{ install_lib_dir }}/openstack_dashboard/static'
@@ -223,7 +223,7 @@ IMAGE_CUSTOM_PROPERTY_TITLES = {
 # OPENSTACK_ENDPOINT_TYPE specifies the endpoint type to use for the endpoints
 # in the Keystone service catalog. Use this setting when Horizon is running
 # external to the OpenStack environment. The default is 'publicURL'.
-OPENSTACK_ENDPOINT_TYPE = " {{ horizon_endpoint_type }} "
+OPENSTACK_ENDPOINT_TYPE = '{{ horizon_endpoint_type }}'
 
 # SECONDARY_ENDPOINT_TYPE specifies the fallback endpoint type to use in the
 # case that OPENSTACK_ENDPOINT_TYPE is not present in the endpoints


### PR DESCRIPTION
This fixes extra whitespace in the OPENSTACK_ENDPOINT_TYPE variable and set debug as a variable. 
