### PR TITLE
Fix nova sshkey gen

### DIFF
--- a/rpc_deployment/playbooks/openstack/nova-all.yml
+++ b/rpc_deployment/playbooks/openstack/nova-all.yml
@@ -19,4 +19,5 @@
 - include: nova-scheduler.yml
 - include: nova-conductor.yml
 - include: nova-compute.yml
+- include: nova-compute-keys.yml
 - include: nova-spice-console.yml

--- a/rpc_deployment/playbooks/openstack/nova-compute-keys.yml
+++ b/rpc_deployment/playbooks/openstack/nova-compute-keys.yml
@@ -13,22 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Prevent known_hosts from causing an issue
-  copy:
-    src: "ssh_config"
-    dest: "/var/lib/nova/.ssh/config"
-    owner: "nova"
-    group: "nova"
-    mode: "0644"
+- hosts: localhost
+  user: root
+  gather_facts: false
+  tasks:
+    - name: Remove [ /tmp/authorized_keys ] file if found
+      file:
+        path: "/tmp/authorized_keys"
+        state: "absent"
 
-- name: Sync authorized_keys file
-  synchronize:
-    src: /tmp/authorized_keys
-    dest: /var/lib/nova/.ssh/authorized_keys
+- hosts: nova_compute
+  user: root
+  roles:
+    - nova_compute_sshkey_create
 
-- name: Set authorized_keys permissions
-  file:
-    path: "/var/lib/nova/.ssh/authorized_keys"
-    owner: "nova"
-    group: "nova"
-    mode: "0600"
+- hosts: nova_compute
+  user: root
+  roles:
+    - nova_compute_sshkey_setup
+
+- hosts: localhost
+  user: root
+  gather_facts: false
+  tasks:
+    - name: Remove [ /tmp/authorized_keys ] file if found
+      file:
+        path: "/tmp/authorized_keys"
+        state: "absent"

--- a/rpc_deployment/playbooks/openstack/nova-compute.yml
+++ b/rpc_deployment/playbooks/openstack/nova-compute.yml
@@ -33,7 +33,6 @@
     - nova_libvirt
     - galera_client_cnf
     - init_script
-    - nova_compute_sshkey_setup
   vars_files:
     - inventory/group_vars/nova_all.yml
     - vars/config_vars/container_config_nova_compute.yml

--- a/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
+++ b/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
@@ -13,7 +13,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Create the keys directory for the nova user
+  file:
+    state: "directory"
+    path: "/var/lib/nova/.ssh"
+    group: "nova"
+    owner: "nova"
+    mode: "0700"
+
+- name: Remove old key if found
+  file:
+    path: "{{ item }}"
+    state: "absent"
+  with_items:
+    - "/var/lib/nova/.ssh/nova"
+    - "/var/lib/nova/.ssh/nova.pub"
+
 - name: Create the nova SSH key if it doesnt exist
-  shell: >
-    ls ~/.ssh/nova 2>/dev/null || ssh-keygen -f ~/.ssh/nova -t rsa -q -N ""
+  shell: ssh-keygen -f /var/lib/nova/.ssh/nova -t rsa -q -N ""
+
+- name: Change permissions on the generated keys
+  file:
+    path: "{{ item.path }}"
+    group: "nova"
+    owner: "nova"
+    mode: "{{ item.mode }}"
+  with_items:
+    - { path: "/var/lib/nova/.ssh/nova", mode: "0600" }
+    - { path: "/var/lib/nova/.ssh/nova.pub", mode: "0644" }
+
+- name: Get public key contents
+  command: cat /var/lib/nova/.ssh/nova.pub
+  register: nova_pub
+  changed_when: false
+
+- name: Build authorized keys
+  lineinfile: 
+    dest: "/tmp/authorized_keys"
+    line: "{{ nova_pub.stdout }}"
+    create: "yes"
   delegate_to: localhost

--- a/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
+++ b/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
@@ -21,16 +21,21 @@
     owner: "nova"
     mode: "0700"
 
+- name: Set nova users shell to /bin/bash and generate ssh_key
+  user:
+    name: "nova"
+    shell: "/bin/bash"
+
 - name: Remove old key if found
   file:
     path: "{{ item }}"
     state: "absent"
   with_items:
-    - "/var/lib/nova/.ssh/nova"
-    - "/var/lib/nova/.ssh/nova.pub"
+    - "/var/lib/nova/.ssh/id_rsa"
+    - "/var/lib/nova/.ssh/id_rsa.pub"
 
 - name: Create the nova SSH key if it doesnt exist
-  shell: ssh-keygen -f /var/lib/nova/.ssh/nova -t rsa -q -N ""
+  shell: shell: su - nova -c 'ssh-keygen -f /var/lib/nova/.ssh/id_rsa -t rsa -q -N ""'
 
 - name: Change permissions on the generated keys
   file:
@@ -39,16 +44,16 @@
     owner: "nova"
     mode: "{{ item.mode }}"
   with_items:
-    - { path: "/var/lib/nova/.ssh/nova", mode: "0600" }
-    - { path: "/var/lib/nova/.ssh/nova.pub", mode: "0644" }
+    - { path: "/var/lib/nova/.ssh/id_rsa", mode: "0600" }
+    - { path: "/var/lib/nova/.ssh/id_rsa.pub", mode: "0644" }
 
 - name: Get public key contents
-  command: cat /var/lib/nova/.ssh/nova.pub
+  command: cat /var/lib/nova/.ssh/id_rsa.pub
   register: nova_pub
   changed_when: false
 
 - name: Build authorized keys
-  lineinfile: 
+  lineinfile:
     dest: "/tmp/authorized_keys"
     line: "{{ nova_pub.stdout }}"
     create: "yes"

--- a/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
+++ b/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
@@ -35,7 +35,7 @@
     - "/var/lib/nova/.ssh/id_rsa.pub"
 
 - name: Create the nova SSH key if it doesnt exist
-  shell: shell: su - nova -c 'ssh-keygen -f /var/lib/nova/.ssh/id_rsa -t rsa -q -N ""'
+  shell: su - nova -c 'ssh-keygen -f /var/lib/nova/.ssh/id_rsa -t rsa -q -N ""'
 
 - name: Change permissions on the generated keys
   file:

--- a/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
+++ b/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
@@ -53,8 +53,5 @@
   changed_when: false
 
 - name: Build authorized keys
-  lineinfile:
-    dest: "/tmp/authorized_keys"
-    line: "{{ nova_pub.stdout }}"
-    create: "yes"
+  shell: echo "{{ nova_pub.stdout }}" | tee -a /tmp/authorized_keys
   delegate_to: localhost


### PR DESCRIPTION
Fixes the #6 and #7 by adding sshkeys for the nova user on a per user per nova compute host basis. This will also rotate the keys per run
