### PR TITLE
Add check for nova-api-metadata

### DIFF
--- a/rpc_deployment/playbooks/monitoring/maas_local.yml
+++ b/rpc_deployment/playbooks/monitoring/maas_local.yml
@@ -109,6 +109,18 @@
   roles:
     - maas_local
 
+- hosts: nova_api_metadata
+  vars:
+    check_name: nova_api_metadata_local_check
+    check_details: file={{ check_name }}.py,args={{ ansible_ssh_host }}
+    check_period: "{{ maas_check_period }}"
+    check_timeout: "{{ maas_check_timeout }}"
+    alarms:
+      - { 'name': 'nova_api_metadata_local_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["nova_api_metadata_local_status"] != 1) { return new AlarmStatus(CRITICAL, "API (metadata) unavailable"); }' }
+  user: root
+  roles:
+    - maas_local
+
 - hosts: nova_api_os_compute
   vars:
     check_name: nova_api_local_check
@@ -116,7 +128,7 @@
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
-      - { 'name': 'nova_api_local_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["nova_api_local_status"] != 1) { return new AlarmStatus(CRITICAL, "API unavailable"); }' }
+      - { 'name': 'nova_api_local_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["nova_api_local_status"] != 1) { return new AlarmStatus(CRITICAL, "API (os-compute) unavailable"); }' }
   user: root
   roles:
     - maas_local


### PR DESCRIPTION
This adds a new maas_local check for the nova-api-metdata service. We
also change the alarm status message for the nova_api_local_status
alarm.

This finishes off issue https://github.com/rcbops/ansible-lxc-rpc/issues/67 but cannot be merged until https://github.com/rcbops/rpc-maas/pull/100 is merged.
