### PR TITLE
Deploy nova-cert

### DIFF
--- a/etc/rpc_deploy/rpc_environment.yml
+++ b/etc/rpc_deploy/rpc_environment.yml
@@ -92,6 +92,9 @@ component_skel:
   nova_api_os_compute:
     belongs_to:
     - nova_all
+  nova_cert:
+    belongs_to:
+    - nova_all
   nova_compute:
     belongs_to:
     - nova_all
@@ -208,6 +211,11 @@ container_skel:
     - infra_containers
     contains:
     - nova_api_os_compute
+  nova_cert_container:
+    belongs_to:
+    - infra_containers
+    contains:
+    - nova_cert
   nova_compute_container:
     is_metal: true
     belongs_to:

--- a/etc/rpc_deploy/rpc_user_config.yml
+++ b/etc/rpc_deploy/rpc_user_config.yml
@@ -15,7 +15,7 @@
 
 # This is the md5 of the environment file
 # this will ensure consistency when deploying.
-environment_version: 5e7155d022462c5a82384c1b2ed8b946
+environment_version: e0955a92a761d5845520a82dcca596af
 
 # User defined CIDR used for containers
 # Global cidr/s used for everything.

--- a/rpc_deployment/playbooks/openstack/nova-cert.yml
+++ b/rpc_deployment/playbooks/openstack/nova-cert.yml
@@ -13,12 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: nova-api-os-compute.yml
-- include: nova-api-ec2.yml
-- include: nova-api-metadata.yml
-- include: nova-scheduler.yml
-- include: nova-conductor.yml
-- include: nova-cert.yml
-- include: nova-compute.yml
-- include: nova-compute-keys.yml
-- include: nova-spice-console.yml
+- hosts: nova_cert
+  user: root
+  roles:
+    - common
+    - common_sudoers
+    - container_common
+    - openstack_common
+    - openstack_openrc
+    - nova_common
+    - galera_client_cnf
+    - init_script
+  vars_files:
+    - inventory/group_vars/nova_all.yml
+    - vars/openstack_service_vars/nova_cert.yml
+    - vars/openstack_service_vars/nova_spice_console_endpoint.yml
+  handlers:
+    - include: handlers/services.yml

--- a/rpc_deployment/vars/openstack_service_vars/nova_cert.yml
+++ b/rpc_deployment/vars/openstack_service_vars/nova_cert.yml
@@ -13,12 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: nova-api-os-compute.yml
-- include: nova-api-ec2.yml
-- include: nova-api-metadata.yml
-- include: nova-scheduler.yml
-- include: nova-conductor.yml
-- include: nova-cert.yml
-- include: nova-compute.yml
-- include: nova-compute-keys.yml
-- include: nova-spice-console.yml
+# The variables file used by the playbooks in the nova-conductor group.
+# These don't have to be explicitly imported by vars_files: they are autopopulated.
+
+program_name: nova-cert


### PR DESCRIPTION
Currently, we do not deploy nova-cert.  As we do not use the ec2 API
extensively we've not run into any issues however it should exist
for those that choose to use the ec2 API.

Closes https://github.com/rcbops/ansible-lxc-rpc/issues/73
