### PR TITLE
Add nova-cert check

### DIFF
--- a/rpc_deployment/playbooks/monitoring/maas_local.yml
+++ b/rpc_deployment/playbooks/monitoring/maas_local.yml
@@ -205,6 +205,18 @@
   roles:
     - maas_local
 
+- hosts: nova_cert
+  vars:
+    check_name: nova_cert_check
+    check_details: file=nova_service_check.py,args=--host,args={{ ansible_hostname }},args={{ internal_vip_address }}
+    check_period: "{{ maas_check_period }}"
+    check_timeout: "{{ maas_check_timeout }}"
+    alarms:
+      - { 'name': 'nova_cert_status', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["nova-cert_status"] != 1) { return new AlarmStatus(CRITICAL, "nova-cert down"); }' }
+  user: root
+  roles:
+    - maas_local
+
 - hosts: nova_conductor
   vars:
     check_name: nova_conductor_check


### PR DESCRIPTION
This adds a check / alarm to maas_local for nova-cert.  We use the
nova_service_check.py plugin and as long as the nova-cert is running
then we'll have entries in the nova service list output for nova-cert.
