### PR TITLE
Adjust symlink for nova-compute logs on metal

### DIFF
--- a/rpc_deployment/roles/nova_compute_devices/tasks/main.yml
+++ b/rpc_deployment/roles/nova_compute_devices/tasks/main.yml
@@ -43,10 +43,25 @@
     udevadm trigger
   when: nova_virt_type == 'kvm'
 
+- name: Create log directory
+  file:
+    path: "/openstack/log/{{ physical_host}}"
+    state: directory
+    owner: nova
+    group: nova
+    mode: 0755
+    force: true
+  when: is_metal == true
+
+- name: Remove old log dir on metal
+  shell: >
+    ls /openstack/log/{{ physical_host }}/nova-compute.log 2>/dev/null || rm -rf /var/log/nova/
+  when: is_metal == true
+
 - name: Create log aggregation links
   file:
-    src: "/var/log/nova"
-    dest: "/openstack/log/nova"
+    src: "/openstack/log/{{ physical_host}}"
+    dest: "/var/log/nova"
     state: "link"
   when: is_metal == true
 


### PR DESCRIPTION
Current symlink isn't mounted on the rsyslog container because its a symlink.
Reversing the symlink will work for rsyslog.
- Create the log directory in /openstack/log with appropriate permissions
- Link to this directory from /var/log/nova
- Adjust the directory to include the physical node name

Fixes #87
