### PR TITLE
Required kernel variant check.

### DIFF
--- a/rpc_deployment/roles/common/tasks/kernel_check.yml
+++ b/rpc_deployment/roles/common/tasks/kernel_check.yml
@@ -15,6 +15,14 @@
 
 # This will check for kernel as defined in the required kernel hash
 
+- name: Check Kernel Variant
+  fail:
+    msg: >
+      Wrong kernel Variant found
+      [ {{ ansible_kernel.split('-')[2] }} != generic ]
+      Resolve this issue before continuing.
+  when: ansible_kernel.split('-')[2] != 'generic'
+
 - name: Check Kernel Version
   fail:
     msg: >


### PR DESCRIPTION
In addition to the kernel version, this adds a kernel variant check, which only allows `generic` kernels.
