### PR TITLE
Resolves Issue 99 which provides for lvm snapshots.

### DIFF
--- a/rpc_deployment/inventory/group_vars/all.yml
+++ b/rpc_deployment/inventory/group_vars/all.yml
@@ -64,6 +64,13 @@ excluded_user_create:
   - rabbitmq
 
 
+## Kernel modules loaded on all hosts
+host_kernel_modules:
+  - scsi_dh
+  - dm_multipath
+  - dm_snapshot
+
+
 ## Base Packages
 apt_common_packages:
   - vlan
@@ -73,6 +80,9 @@ apt_common_packages:
   - git-core
   - rsyslog
   - lvm2
+  - dmeventd
+  - libkmod-dev
+  - libkmod2
   - libssl-dev
   - bridge-utils
   - cgroup-lite

--- a/rpc_deployment/inventory/group_vars/cinder_all.yml
+++ b/rpc_deployment/inventory/group_vars/cinder_all.yml
@@ -89,4 +89,3 @@ container_packages:
   - libkmod-dev
   - libkmod2
   - dmeventd
-

--- a/rpc_deployment/roles/host_common/tasks/kernel_modules.yml
+++ b/rpc_deployment/roles/host_common/tasks/kernel_modules.yml
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: sysstat.yml
-- include: updatehostsfile.yml
-- include: authorized_keys.yml
-- include: kernel_modules.yml
+- name: "Ensure kernel module(s)"
+  modprobe:
+    name: "{{ item }}"
+  with_items: host_kernel_modules
+  when: host_kernel_modules is defined
+
+- name: "Ensure kernel module(s) loaded at boot"
+  lineinfile:
+    dest: /etc/modules
+    line: "{{ item }}"
+  with_items: host_kernel_modules
+  when: host_kernel_modules is defined

--- a/rpc_deployment/vars/config_vars/container_config_nova_compute.yml
+++ b/rpc_deployment/vars/config_vars/container_config_nova_compute.yml
@@ -50,6 +50,9 @@ kernel_modules:
   - nf_conntrack
   - x_tables
   - iscsi_tcp
+  - scsi_dh
+  - dm_multipath
+  - dm_snapshot
 
 sysctl_options:
   - { key: 'net.ipv4.conf.all.rp_filter', value: 0 }


### PR DESCRIPTION
- added host kernel modules as well as packages which should be on all hosts.
- ensures that the kernel modules required on all hosts are loaded
- added modules that compute will need

Issue #99 
ansible: 1.6.6
