### PR TITLE
Allow instance resize on same host

### DIFF
--- a/rpc_deployment/roles/nova_common/templates/nova.conf
+++ b/rpc_deployment/roles/nova_common/templates/nova.conf
@@ -15,7 +15,7 @@ compute_driver = {{ nova_compute_driver }}
 instance_name_template = instance-%08x
 instances_path = /var/lib/nova/instances
 api_paste_config = /etc/nova/api-paste.ini
-allow_resize_to_same_host = False
+allow_resize_to_same_host = True
 
 # Api's
 enabled_apis = osapi_compute,metadata,ec2


### PR DESCRIPTION
In v4.2.x, allow_resize_to_same_host defaults to True so that in resource
constrained installations, a resize can happen on the existing host if
there are enough resources there to do it.
- Change allow_resize_to_same_host to True to prevent resize regression in
  9.0.0

Fixes rcbops/ansible-lxc-rpc#104
