### PR TITLE
Allow an fqdn extension to be specified for MaaS purposes

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -112,7 +112,10 @@ maas_monitoring_zones:
   - mzlon
   - mzhkg
 maas_repo_version: v9.0.0
-
+# Specify the maas_fqdn_extension, defaults to empty string.
+# This will be appended to the inventory_name of a host for MaaS purposes.
+# The inventory name + maas_fqdn_extension must match the entity name in MaaS
+# maas_fqdn_extension: .example.com
 
 ## Neutron Options
 neutron_container_mysql_password:

--- a/rpc_deployment/playbooks/monitoring/raxmon-setup.yml
+++ b/rpc_deployment/playbooks/monitoring/raxmon-setup.yml
@@ -20,7 +20,7 @@
     - raxmon_cli
     - raxmon_agent_install
   vars:
-    entity_name: "{{ inventory_hostname }}"
+    entity_name: "{{ inventory_hostname }}{{ maas_fqdn_extension|default('') }}"
 
 - hosts: keystone[0]
   user: root

--- a/rpc_deployment/roles/maas_dell_hardware/tasks/main.yml
+++ b/rpc_deployment/roles/maas_dell_hardware/tasks/main.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Get entity ID for physical_host
-  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
+  shell: raxmon-entities-list  | grep "label={{ inventory_hostname|quote }}{{ maas_fqdn_extension|default('') }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
   register: entity_id
 
 - name: Validate if check exists

--- a/rpc_deployment/roles/maas_local/tasks/main.yml
+++ b/rpc_deployment/roles/maas_local/tasks/main.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Get entity ID for physical_host
-  shell: raxmon-entities-list  | grep "label={{ physical_host|quote }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
+  shell: raxmon-entities-list  | grep "label={{ physical_host|quote }}{{ maas_fqdn_extension|default('') }} " | sed -e 's/^.* id=\(.*\) label=.*$/\1/g'
   register: entity_id
   delegate_to: "{{ physical_host }}"
 


### PR DESCRIPTION
This allows the inventory_hostname to be specified as the shortname, and
a common fqdn to applied. E.g. infra01 with an fqdn of .test.com would
count towards a MaaS entity of infra01.test.com whilst the inventory for
ansible would still see it as "infra01".
