### PR TITLE
Separate out the Cloud Files tenant_id and regular Cloud tenant_id

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -17,6 +17,9 @@
 # UK accounts: https://lon.identity.api.rackspacecloud.com/v2.0
 rackspace_cloud_auth_url: https://identity.api.rackspacecloud.com/v2.0
 rackspace_cloud_tenant_id: SomeTenantID
+# The cloudfiles_tenant_id is the long MossoCloudFS tenantID only required
+# when using glance backed by Rackspace Cloud Files
+rackspace_cloudfiles_tenant_id: SomeTenantID
 rackspace_cloud_username: SomeUserName
 rackspace_cloud_password: SomeUsersPassword
 rackspace_cloud_api_key: SomeAPIKey
@@ -54,11 +57,12 @@ cinder_v2_service_password:
 
 
 ## Glance Options
+# Set default_store to "swift" if using Cloud Files or swift backend
 glance_default_store: file
 glance_container_mysql_password:
 glance_service_password:
 glance_swift_store_auth_address: "{{ rackspace_cloud_auth_url }}"
-glance_swift_store_user: "{{ rackspace_cloud_tenant_id }}:{{ rackspace_cloud_username }}"
+glance_swift_store_user: "{{ rackspace_cloudfiles_tenant_id }}:{{ rackspace_cloud_username }}"
 glance_swift_store_key: "{{ rackspace_cloud_password }}"
 glance_swift_store_container: SomeContainerName
 glance_swift_store_region: SomeRegion


### PR DESCRIPTION
Cloud Files uses the MossoFS tenant, this is not the same as the
tenant_id used for authenticating with Rackspace Cloud.
- Separate out the 2 settings in user_variables to ensure these are
  noted as being different values.

Fixes #103
