### PR TITLE
fixed typo where fields were missing the 'volume_' prefix

### DIFF
--- a/etc/rpc_deploy/rpc_user_config.yml
+++ b/etc/rpc_deploy/rpc_user_config.yml
@@ -145,8 +145,8 @@ storage_hosts:
         limit_container_types: cinder_volume
         lvm:
           volume_group: cinder-volumes
-          driver: cinder.volume.drivers.lvm.LVMISCSIDriver
-          backend_name: LVM_iSCSI
+          volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+          volume_backend_name: LVM_iSCSI
 
 # User defined Logging Hosts, this should be a required group
 log_hosts:

--- a/etc/rpc_deploy/rpc_user_config.yml.example
+++ b/etc/rpc_deploy/rpc_user_config.yml.example
@@ -165,8 +165,8 @@ storage_hosts:
         limit_container_types: cinder_volume
         lvm:
           volume_group: cinder-volumes
-          driver: cinder.volume.drivers.lvm.LVMISCSIDriver
-          backend_name: LVM_iSCSI
+          volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+          volume_backend_name: LVM_iSCSI
   cinder2:
     ip: 172.29.236.105
     container_vars:
@@ -174,8 +174,8 @@ storage_hosts:
         limit_container_types: cinder_volume
         lvm_ssd:
           volume_group: cinder-volumes
-          driver: cinder.volume.drivers.lvm.LVMISCSIDriver
-          backend_name: LVM_SSD_iSCSI
+          volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+          volume_backend_name: LVM_SSD_iSCSI
   cinder3:
     ip: 172.29.236.106
     container_vars:
@@ -188,8 +188,8 @@ storage_hosts:
           netapp_server_port: 80
           netapp_login: "{{ cinder_netapp_username }}"
           netapp_password: "{{ cinder_netapp_password }}"
-          driver: cinder.volume.drivers.netapp.common.NetAppDriver
-          backend_name: NETAPP_iSCSI
+          volume_driver: cinder.volume.drivers.netapp.common.NetAppDriver
+          volume_backend_name: NETAPP_iSCSI
 
 # User defined Logging Hosts, this should be a required group
 log_hosts:

--- a/rpc_deployment/roles/cinder_backend_types/tasks/main.yml
+++ b/rpc_deployment/roles/cinder_backend_types/tasks/main.yml
@@ -24,6 +24,6 @@
   shell: |
     . ~/openrc
     cinder type-create "{{ item.0 }}"
-    cinder type-key "{{ item.0 }}" set volume_backend_name="{{ cinder_backends[item.0]['backend_name'] }}"
+    cinder type-key "{{ item.0 }}" set volume_backend_name="{{ cinder_backends[item.0]['volume_backend_name'] }}"
   with_items: cinder_backends|dictsort
   when: cinder_backends is defined


### PR DESCRIPTION
This PR resolves a rather large typo in our example configs which makes multi-node with multi-storage backends impossible and effects all storage types and schedulers. While the fix is mainly in the exmaples, there is one method `Add in cinder devices types` which needs to be updated as it uses the name to setup the storage type to a pre-determined  scheduler. 
