### PR TITLE
Resolves the rootwrap and MTU issues within neutron

### DIFF
--- a/rpc_deployment/roles/neutron_common/tasks/main.yml
+++ b/rpc_deployment/roles/neutron_common/tasks/main.yml
@@ -67,6 +67,8 @@
     - dhcp_agent.ini
     - api-paste.ini
     - policy.json
+    - dnsmasq-neutron.conf
+    - rootwrap.conf
     - plugins/ml2/ml2_conf.ini
     - rootwrap.d/debug.filters
     - rootwrap.d/dhcp.filters

--- a/rpc_deployment/roles/neutron_common/templates/dhcp_agent.ini
+++ b/rpc_deployment/roles/neutron_common/templates/dhcp_agent.ini
@@ -3,3 +3,4 @@ interface_driver = {{ interface_driver }}
 dhcp_driver = {{ dhcp_driver }}
 use_namespaces = True
 enable_isolated_metadata = True
+dnsmasq_config_file = /etc/neutron/dnsmasq-neutron.conf

--- a/rpc_deployment/roles/neutron_common/templates/dnsmasq-neutron.conf
+++ b/rpc_deployment/roles/neutron_common/templates/dnsmasq-neutron.conf
@@ -1,0 +1,1 @@
+dhcp-option-force=26,1450

--- a/rpc_deployment/roles/neutron_common/templates/rootwrap.conf
+++ b/rpc_deployment/roles/neutron_common/templates/rootwrap.conf
@@ -1,0 +1,34 @@
+# Configuration for neutron-rootwrap
+# This file should be owned by (and only-writeable by) the root user
+
+[DEFAULT]
+# List of directories to load filter definitions from (separated by ',').
+# These directories MUST all be only writeable by root !
+filters_path=/etc/neutron/rootwrap.d,/usr/share/neutron/rootwrap,/etc/quantum/rootwrap.d,/usr/share/quantum/rootwrap
+
+# List of directories to search executables in, in case filters do not
+# explicitely specify a full path (separated by ',')
+# If not specified, defaults to system PATH environment variable.
+# These directories MUST all be only writeable by root !
+exec_dirs=/sbin,/usr/sbin,/bin,/usr/bin
+
+# Enable logging to syslog
+# Default value is False
+use_syslog=False
+
+# Which syslog facility to use.
+# Valid values include auth, authpriv, syslog, local0, local1...
+# Default value is 'syslog'
+syslog_log_facility=syslog
+
+# Which messages to log.
+# INFO means log all usage
+# ERROR means only log unsuccessful attempts
+syslog_log_level=ERROR
+
+[xenapi]
+# XenAPI configuration is only required by the L2 agent if it is to
+# target a XenServer/XCP compute host's dom0.
+xenapi_connection_url=<None>
+xenapi_connection_username=root
+xenapi_connection_password=<None>


### PR DESCRIPTION
When using neutron vxlan the mtu needs to be set to 1450 in the dnsmasq config. If this is not set inner-instance networking will be broken on most images. This change comes directly from the Neutron configuration documentation per @ionosphere80 and has been confirmed by @busterswt .
