### PR TITLE
changed ansible install from the package name to a URL as a tarball

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Jinja2==2.7.3
 MarkupSafe==0.23
 PyYAML==3.11
-ansible==1.6.6
 click==2.5
 colorize==1.0.2
 ecdsa==0.11
@@ -15,3 +14,4 @@ requests==2.4.1
 cloudlib==0.0.8
 pip==1.5.6
 wheel==0.24.0
+http://rpc-slushee.rackspace.com/downloads/ansible-1.6.10.tar.gz


### PR DESCRIPTION
This change effects is to ensure that the version of Ansible we are depending on is always the same and that all of the ansible resources are always available. 
