### PR TITLE
updated repo url variable and fixed rax heat template to use rax cloud resources

### DIFF
--- a/scripts/cloudserver-aio.sh
+++ b/scripts/cloudserver-aio.sh
@@ -16,7 +16,7 @@ set -e -u -v -x
 
 REPO_URL=${REPO_URL:-"https://github.com/rcbops/ansible-lxc-rpc.git"}
 REPO_BRANCH=${REPO_BRANCH:-"master"}
-FROZEN_REPO_URL=${FROZEN_REPO:-"http://rpc-slushee.rackspace.com"}
+FROZEN_REPO_URL=${FROZEN_REPO_URL:-"http://rpc-slushee.rackspace.com"}
 MAX_RETRIES=${MAX_RETRIES:-5}
 
 apt-get update

--- a/scripts/rpc9.0.0-aio-rax-heat-template.yml
+++ b/scripts/rpc9.0.0-aio-rax-heat-template.yml
@@ -53,7 +53,7 @@ outputs:
     value: secrete
 resources:
   RPCAIO:
-    type: OS::Nova::Server
+    type: "Rackspace::Cloud::Server"
     properties:
       flavor: { get_param: flavor_name }
       image: { get_param: image_name }


### PR DESCRIPTION
RAX cloud orchestration requires the resource type "Rackspace::Cloud::Server" even through the documentation says that the resource "OS::Nova::Server" should be used instead. 
