### PR TITLE
Fixes #130 by adding configurations for heat and horizon

### DIFF
--- a/rpc_deployment/roles/horizon_apache/templates/openstack-dashboard.conf
+++ b/rpc_deployment/roles/horizon_apache/templates/openstack-dashboard.conf
@@ -9,8 +9,8 @@
     ServerName {{ horizon_server_name }}
 
     LogLevel  {{  horizon_log_level|default('info') }}
-    ErrorLog  /var/log/apache2/horizon-error.log
-    CustomLog /var/log/apache2/ssl_access.log combined
+    ErrorLog  /var/log/horizon/horizon-error.log
+    CustomLog /var/log/horizon/ssl_access.log combined
     Options +FollowSymLinks
 
     SSLEngine on

--- a/rpc_deployment/roles/kibana/templates/Next-Gen-RPC.json
+++ b/rpc_deployment/roles/kibana/templates/Next-Gen-RPC.json
@@ -65,6 +65,15 @@
           "type": "lucene",
           "enable": true,
           "query": "tags:rsyslog*"
+        },
+        "7": {
+          "id": 7,
+          "color": "#BA43A9",
+          "alias": "",
+          "pin": false,
+          "type": "lucene",
+          "enable": true,
+          "query": "tags:heat*"
         }
       },
       "ids": [
@@ -74,7 +83,8 @@
         3,
         4,
         5,
-        6
+        6,
+        7
       ]
     },
     "filter": {

--- a/rpc_deployment/roles/logstash/templates/03-generic.conf
+++ b/rpc_deployment/roles/logstash/templates/03-generic.conf
@@ -93,11 +93,18 @@ filter {
         }
         #-----------------------------------------------------------------------
         # Parse & tag generic glance logs
-        # i.e.:
-        # 1) neutron.log: 2014-06-11 16:00:30.546 4131 INFO cinder.api.openstack.wsgi [-] http://10.127.26.62:8776/ returned with HTTP 200
         grok {
             match => ["os_program", "glance.%{GREEDYDATA:os_program_path}"]
             add_tag => [ "glance-generic" ]
+            break_on_match => false
+            tag_on_failure => []
+        }
+
+        #-----------------------------------------------------------------------
+        # Parse & tag generic heat logs
+        grok {
+            match => ["os_program", "heat.%{GREEDYDATA:os_program_path}"]
+            add_tag => [ "heat-generic" ]
             break_on_match => false
             tag_on_failure => []
         }


### PR DESCRIPTION
Addresses issue #130 by doing the following: added configuration for Logstash and Kibana to parse and display Heat logs.  Also changed the logging location of horizon logs so that rsyslog can easily pick them up.
