### PR TITLE
fixed an issue where a lookup would fail due to recursive children

### DIFF
--- a/rpc_deployment/inventory/dynamic_inventory.py
+++ b/rpc_deployment/inventory/dynamic_inventory.py
@@ -435,7 +435,7 @@ def _add_additional_networks(key, inventory, ip_q, k_name, netmask):
     """
     base_hosts = inventory['_meta']['hostvars']
     addr_name = '%s_address' % k_name
-    lookup = inventory[key]
+    lookup = inventory.get(key, list())
 
     if 'children' in lookup and lookup['children']:
         for group in lookup['children']:


### PR DESCRIPTION
This fix resolves an issue where we were performing a hard key lookup but this was failing due to how the method uses group recursion. This change now allows the method to return None and set an empty list if the key is not ready or has no valid hosts.
