### PR TITLE
Nova scheduler

### DIFF
--- a/rpc_deployment/inventory/group_vars/nova_all.yml
+++ b/rpc_deployment/inventory/group_vars/nova_all.yml
@@ -68,14 +68,14 @@ nova_compute_driver: libvirt.LibvirtDriver
 nova_max_age: 0
 
 # Nova Scheduler
-nova_cpu_allocation_ratio: 10.0
+nova_cpu_allocation_ratio: 5.0
 nova_disk_allocation_ratio: 1.0
 nova_max_instances_per_host: 50
 nova_max_io_ops_per_host: 10
 nova_ram_allocation_ratio: 1.5
 nova_ram_weight_multiplier: 5.0
-nova_reserved_host_disk_mb: 1024
-nova_reserved_host_memory_mb: 512
+nova_reserved_host_disk_mb: 2048
+nova_reserved_host_memory_mb: 2048
 nova_scheduler_driver: nova.scheduler.filter_scheduler.FilterScheduler
 nova_scheduler_available_filters: nova.scheduler.filters.all_filters
 nova_scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter

--- a/rpc_deployment/inventory/group_vars/nova_all.yml
+++ b/rpc_deployment/inventory/group_vars/nova_all.yml
@@ -67,6 +67,26 @@ nova_firewall_driver: nova.virt.firewall.NoopFirewallDriver
 nova_compute_driver: libvirt.LibvirtDriver
 nova_max_age: 0
 
+# Nova Scheduler
+nova_cpu_allocation_ratio: 10.0
+nova_disk_allocation_ratio: 1.0
+nova_max_instances_per_host: 50
+nova_max_io_ops_per_host: 10
+nova_ram_allocation_ratio: 1.5
+nova_ram_weight_multiplier: 5.0
+nova_reserved_host_disk_mb: 1024
+nova_reserved_host_memory_mb: 512
+nova_scheduler_driver: nova.scheduler.filter_scheduler.FilterScheduler
+nova_scheduler_available_filters: nova.scheduler.filters.all_filters
+nova_scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter
+nova_scheduler_driver: nova.scheduler.filter_scheduler.FilterScheduler
+nova_scheduler_driver_task_period: 60
+nova_scheduler_host_manager: nova.scheduler.host_manager.HostManager
+nova_scheduler_host_subset_size: 10
+nova_scheduler_manager: nova.scheduler.manager.SchedulerManager
+nova_scheduler_max_attempts: 5
+nova_scheduler_weight_classes: nova.scheduler.weights.all_weighers
+
 ## Git Source
 ## ALL of this has been relocated to vars/repo_packages
 ## TODO(someone) this should be removed once the repo bits are all figured out.

--- a/rpc_deployment/inventory/group_vars/nova_all.yml
+++ b/rpc_deployment/inventory/group_vars/nova_all.yml
@@ -79,7 +79,6 @@ nova_reserved_host_memory_mb: 512
 nova_scheduler_driver: nova.scheduler.filter_scheduler.FilterScheduler
 nova_scheduler_available_filters: nova.scheduler.filters.all_filters
 nova_scheduler_default_filters: RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter
-nova_scheduler_driver: nova.scheduler.filter_scheduler.FilterScheduler
 nova_scheduler_driver_task_period: 60
 nova_scheduler_host_manager: nova.scheduler.host_manager.HostManager
 nova_scheduler_host_subset_size: 10

--- a/rpc_deployment/roles/nova_common/templates/nova.conf
+++ b/rpc_deployment/roles/nova_common/templates/nova.conf
@@ -20,7 +20,6 @@ reserved_host_memory_mb = {{ nova_reserved_host_memory_mb }}
 scheduler_driver = {{ nova_scheduler_driver }}
 scheduler_available_filters = {{ nova_scheduler_available_filters }}
 scheduler_default_filters = {{ nova_scheduler_default_filters }}
-scheduler_driver = {{ nova_scheduler_driver }}
 scheduler_driver_task_period = {{ nova_scheduler_driver_task_period }}
 scheduler_host_manager = {{ nova_scheduler_host_manager }}
 scheduler_host_subset_size = {{ nova_scheduler_host_subset_size }}

--- a/rpc_deployment/roles/nova_common/templates/nova.conf
+++ b/rpc_deployment/roles/nova_common/templates/nova.conf
@@ -6,9 +6,27 @@ log_dir = /var/log/nova
 state_path = /var/lib/nova
 lock_path = /var/lock/nova
 rootwrap_config = /etc/nova/rootwrap.conf
+service_down_time = 120
 
 # Scheduler
-scheduler_driver = nova.scheduler.filter_scheduler.FilterScheduler
+cpu_allocation_ratio = {{ nova_cpu_allocation_ratio }}
+disk_allocation_ratio = {{ nova_disk_allocation_ratio }}
+max_instances_per_host = {{ nova_max_instances_per_host }}
+max_io_ops_per_host = {{ nova_max_io_ops_per_host }}
+ram_allocation_ratio = {{ nova_ram_allocation_ratio }}
+ram_weight_multiplier = {{ nova_ram_weight_multiplier }}
+reserved_host_disk_mb = {{ nova_reserved_host_disk_mb }}
+reserved_host_memory_mb = {{ nova_reserved_host_memory_mb }}
+scheduler_driver = {{ nova_scheduler_driver }}
+scheduler_available_filters = {{ nova_scheduler_available_filters }}
+scheduler_default_filters = {{ nova_scheduler_default_filters }}
+scheduler_driver = {{ nova_scheduler_driver }}
+scheduler_driver_task_period = {{ nova_scheduler_driver_task_period }}
+scheduler_host_manager = {{ nova_scheduler_host_manager }}
+scheduler_host_subset_size = {{ nova_scheduler_host_subset_size }}
+scheduler_manager = {{ nova_scheduler_manager }}
+scheduler_max_attempts = {{ nova_scheduler_max_attempts }}
+scheduler_weight_classes = {{ nova_scheduler_weight_classes }}
 
 # Compute
 compute_driver = {{ nova_compute_driver }}


### PR DESCRIPTION
This PR adds sane limits in nova. Presently the nova scheduler is set to filter though has no set filters. This allows a user to spin up a potentially unlimited number of vm's which eventually causes the host to become overloaded. Additionally the unset scheduler seems to stack vm's on a single host instead of spreading them out on all compute nodes. While this PR provides for sane settings it also allows any scheduler tunable to be changed as needed.
