### PR TITLE
swap nova default / fallback repos

### DIFF
--- a/rpc_deployment/inventory/group_vars/nova_all.yml
+++ b/rpc_deployment/inventory/group_vars/nova_all.yml
@@ -70,8 +70,8 @@ nova_max_age: 0
 ## Git Source
 ## ALL of this has been relocated to vars/repo_packages
 ## TODO(someone) this should be removed once the repo bits are all figured out.
-git_repo: https://git.openstack.org/openstack/nova
-git_fallback_repo: https://github.com/openstack/nova
+git_repo: https://github.com/openstack/nova
+git_fallback_repo: https://git.openstack.org/openstack/nova
 git_etc_example: etc/nova/
 git_install_branch: 9ada982ccdb974d43c1c94e59eb4b84e35a7997d
 

--- a/rpc_deployment/vars/repo_packages/nova.yml
+++ b/rpc_deployment/vars/repo_packages/nova.yml
@@ -18,8 +18,8 @@ repo_package_name: nova
 repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/nova
-git_fallback_repo: https://github.com/openstack/nova
+git_repo: https://github.com/openstack/nova
+git_fallback_repo: https://git.openstack.org/openstack/nova
 git_dest: "/opt/{{ repo_path }}"
 git_etc_example: etc/nova/
 git_install_branch: master


### PR DESCRIPTION
swapped default and fallback repos for nova, QE was seeing multiple long timeouts when cloning from git.openstack.org
