### PR TITLE
Added open file limits to rabbitmq

### DIFF
--- a/rpc_deployment/roles/rabbit_common/tasks/main.yml
+++ b/rpc_deployment/roles/rabbit_common/tasks/main.yml
@@ -67,8 +67,11 @@
 
 - name: Create rabbitmq config
   template:
-    src: rabbitmq.config
-    dest: /etc/rabbitmq/rabbitmq.config
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - { src: "rabbitmq.config", dest: "/etc/rabbitmq/rabbitmq.config" }
+    - { src: "rabbitmq-server", dest: "/etc/default/rabbitmq-server" }
   tags:
     - rabbit_config
 

--- a/rpc_deployment/roles/rabbit_common/templates/rabbitmq-server
+++ b/rpc_deployment/roles/rabbit_common/templates/rabbitmq-server
@@ -1,0 +1,2 @@
+# Sets open file limit for RabbitMQ
+ulimit -n 4096


### PR DESCRIPTION
This PR resolves an issue with open files that causes rabbitmq to become unresponsive under heavy workload.

Resolves issue: https://github.com/rcbops/ansible-lxc-rpc/issues/159
