### PR TITLE
Configures IRQbalance

### DIFF
--- a/rpc_deployment/roles/host_common/handlers/main.yml
+++ b/rpc_deployment/roles/host_common/handlers/main.yml
@@ -15,3 +15,6 @@
 
 - name: Restart sysstat
   service: name=sysstat state=restarted pattern=sysstat enabled=yes
+
+- name: Restart irqbalance
+  service: name=irqbalance state=restarted pattern=irqbalance enabled=yes

--- a/rpc_deployment/roles/host_common/tasks/irqbalance.yml
+++ b/rpc_deployment/roles/host_common/tasks/irqbalance.yml
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: sysstat.yml
-- include: updatehostsfile.yml
-- include: authorized_keys.yml
-- include: kernel_modules.yml
-- include: irqbalance.yml
+- name: Drop irqbalance default
+  template:
+    src: "irqbalance"
+    dest: "/etc/default/irqbalance"
+  notify: Restart irqbalance

--- a/rpc_deployment/roles/host_common/templates/ircbalance
+++ b/rpc_deployment/roles/host_common/templates/ircbalance
@@ -1,0 +1,9 @@
+#Configuration for the irqbalance daemon
+
+#Should irqbalance be enabled?
+ENABLED="1"
+#Balance the IRQs only once?
+ONESHOT="0"
+
+# Ignore hints
+OPTIONS="--hintpolicy=ignore"


### PR DESCRIPTION
Sets the irqbalance hint policy to "ignore". This resolves an issue where irqbalance will consume 100% CPU under heavy workload.

Resolves Issue: https://github.com/rcbops/ansible-lxc-rpc/issues/161
