### PR TITLE
Adds limits config to galera_common

### DIFF
--- a/rpc_deployment/roles/galera_common/tasks/main.yml
+++ b/rpc_deployment/roles/galera_common/tasks/main.yml
@@ -30,6 +30,11 @@
     - root_password
     - root_password_again
 
+- name: Drop limits config
+  template:
+    src: "limits.conf"
+    dest: "/etc/security/limits.conf"
+
 - name: Install galera packages
   apt:
     pkg: "{{ item }}"

--- a/rpc_deployment/roles/galera_common/templates/limits.conf
+++ b/rpc_deployment/roles/galera_common/templates/limits.conf
@@ -1,0 +1,2 @@
+# OpenFile limits
+*    -    nofile    16384


### PR DESCRIPTION
Adds an open file limit to galera per the galera documentation. [https://mariadb.com/kb/en/mariadb/development/quality/benchmarks-and-long-running-tests/benchmarks/recommended-settings-for-benchmarks/]

Resolves Issue: https://github.com/rcbops/ansible-lxc-rpc/issues/160
