### PR TITLE
changes default hypervisor to KVM

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -128,7 +128,9 @@ neutron_service_password:
 
 
 ## Nova Options
-nova_virt_type: qemu
+# This defaults to KVM, if you are deploying on a host that is not KVM capable
+# change this to your hypervisor type: IE "qemu", "lxc".
+# nova_virt_type: kvm
 nova_container_mysql_password:
 nova_metadata_proxy_secret:
 nova_ec2_service_password:

--- a/rpc_deployment/inventory/group_vars/nova_all.yml
+++ b/rpc_deployment/inventory/group_vars/nova_all.yml
@@ -39,7 +39,7 @@ container_database: nova
 rpc_backend: nova.openstack.common.rpc.impl_kombu
 
 ## Nova virtualization Type, set to KVM if supported
-virt_type: "{{ nova_virt_type|default('qemu') }}"
+virt_type: "{{ nova_virt_type|default('kvm') }}"
 
 ## Nova Auth
 service_admin_tenant_name: "service"


### PR DESCRIPTION
This PR sets the default hypervisor to KVM.

Resolves issue: https://github.com/rcbops/ansible-lxc-rpc/issues/147
