### PR TITLE
added package files for rax-mon

### DIFF
--- a/rpc_deployment/vars/repo_packages/rackspace_monitoring.yml
+++ b/rpc_deployment/vars/repo_packages/rackspace_monitoring.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+repo_package_name: rackspace-monitoring
+
+repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
+
+git_repo: https://github.com/racker/rackspace-monitoring
+git_install_branch: "v0.6.4"
+git_dest: "/opt/{{ repo_path }}"
+
+pip_wheel_name: rackspace-monitoring

--- a/rpc_deployment/vars/repo_packages/rackspace_monitoring_cli.yml
+++ b/rpc_deployment/vars/repo_packages/rackspace_monitoring_cli.yml
@@ -1,0 +1,24 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+repo_package_name: rackspace-monitoring-cli
+
+repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
+
+git_repo: https://github.com/racker/rackspace-monitoring-cli
+git_install_branch: "v0.6.6"
+git_dest: "/opt/{{ repo_path }}"
+
+pip_wheel_name: rackspace-monitoring-cli


### PR DESCRIPTION
This PR adds repo_package var files to stabilize versions used for Rackspace monitoring.

Resolves issue: https://github.com/rcbops/ansible-lxc-rpc/issues/150
