### PR TITLE
change the help URL in Horizon so that it can be overriden

### DIFF
--- a/rpc_deployment/inventory/group_vars/horizon.yml
+++ b/rpc_deployment/inventory/group_vars/horizon.yml
@@ -41,6 +41,10 @@ system_user: www-data
 system_group: www-data
 
 
+## Horizon Help URL Path
+horizon_help_url: http://docs.rackspace.com/rpc/api/v9/rpc-faq-v9/content/rpc-common-front.html
+
+
 # Installation directories
 install_lib_dir: /usr/local/lib/python2.7/dist-packages
 

--- a/rpc_deployment/roles/horizon_common/templates/local_settings.py
+++ b/rpc_deployment/roles/horizon_common/templates/local_settings.py
@@ -59,7 +59,7 @@ HORIZON_CONFIG = {
         'fade_duration': 1500,
         'types': ['alert-success', 'alert-info']
     },
-    'help_url': "http://docs.openstack.org",
+    'help_url': "{{ horizon_help_url|default('http://docs.openstack.org') }}",
     'exceptions': {
         'recoverable': exceptions.RECOVERABLE,
         'not_found': exceptions.NOT_FOUND,


### PR DESCRIPTION
Adds a default help URL as a variable to horizon.

Fixes Issue: https://github.com/rcbops/ansible-lxc-rpc/issues/105
