### PR TITLE
ensure neutron db migrations include juno (currently 'head')

### DIFF
--- a/rpc_deployment/inventory/group_vars/neutron_all.yml
+++ b/rpc_deployment/inventory/group_vars/neutron_all.yml
@@ -42,7 +42,7 @@ service_plugins:
 dhcp_driver: neutron.agent.linux.dhcp.Dnsmasq
 neutron_config: /etc/neutron/neutron.conf
 neutron_plugin: /etc/neutron/plugins/ml2/ml2_conf.ini
-neutron_revision: icehouse
+neutron_revision: head
 
 ## Neutron downtime
 neutron_agent_down_time: 120


### PR DESCRIPTION
Once there is a juno revision, we can change to that.
