### PR TITLE
Temporarily use heat's heat-keystone-setup-domain

### DIFF
--- a/rpc_deployment/inventory/group_vars/heat_all.yml
+++ b/rpc_deployment/inventory/group_vars/heat_all.yml
@@ -55,6 +55,7 @@ service_names:
 ## Stack 
 stack_domain_admin_password: "{{ heat_stack_domain_admin_password }}"
 stack_domain_admin: heat_domain_admin
+stack_user_domain_name: heat
 deferred_auth_method: trusts
 
 auth_encryption_key: "{{ heat_auth_encryption_key }}"

--- a/rpc_deployment/roles/heat_common/tasks/heat_config.yml
+++ b/rpc_deployment/roles/heat_common/tasks/heat_config.yml
@@ -13,19 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Ensure Heat Domain User
-  keystone: >
-    command=ensure_user
-    token="{{ auth_admin_token }}"
-    endpoint="{{ auth_admin_uri }}"
-    user_name="{{ stack_domain_admin }}"
-    tenant_name=admin
-    password="{{ stack_domain_admin_password }}"
-
-- name: set fact for heat domain admin id
-  set_fact:
-    stack_user_domain: "{{ keystone_facts['id'] }}"
-
 - name: Setup Heat Config
   template: >
     src={{ item }}

--- a/rpc_deployment/roles/heat_common/templates/heat.conf
+++ b/rpc_deployment/roles/heat_common/templates/heat.conf
@@ -7,7 +7,7 @@ log_file = /var/log/heat/heat.log
 
 stack_domain_admin_password = {{ stack_domain_admin_password }}
 stack_domain_admin = {{ stack_domain_admin }}
-stack_user_domain = {{ stack_user_domain }}
+stack_user_domain_id = {{ hostvars[groups['heat_api'][0]]['stack_user_domain_id'] }}
 deferred_auth_method = {{ deferred_auth_method }}
 
 auth_encryption_key = {{ auth_encryption_key }}

--- a/rpc_deployment/roles/heat_domain_user/tasks/main.yml
+++ b/rpc_deployment/roles/heat_domain_user/tasks/main.yml
@@ -13,15 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Ensure heat domain user
-  keystone: >
-    command=ensure_user
-    token="{{ auth_admin_token }}"
-    endpoint="{{ auth_admin_uri }}"
-    user_name="{{ stack_domain_admin }}"
-    tenant_name=admin
-    password="{{ stack_domain_admin_password }}"
-
 - name: Ensure stack_owner role
   keystone: >
     command=ensure_role
@@ -41,3 +32,16 @@
     user_name="admin"
     tenant_name="admin"
     role_name="heat_stack_owner"
+
+- name: Create heat domain and domain user
+  shell: |
+    . /root/openrc
+    /usr/local/bin/heat-keystone-setup-domain --stack-domain-admin {{ stack_domain_admin }} \
+                                              --stack-domain-admin-password {{ stack_domain_admin_password }} \
+                                              --stack-user-domain-name {{ stack_user_domain_name }} | \
+                                              awk -F\= '/stack_user_domain_id/ {print $2}'
+  register: stack_user_domain_id
+
+- name: Set fact for heat domain id
+  set_fact:
+    stack_user_domain_id: "{{ stack_user_domain_id.stdout }}"


### PR DESCRIPTION
Heat in juno relies on keystone domains, however our lxc keystone module
does not support this functionality (which requires keystone v3).  Our
long-term goal should be to update our keystone ansible module however
there are larger implications in moving that module over to using v3
for all calls.

This commit bypasses using the keystone module and shells out to
heat-keystone-setup-domain which sets up the keystone domain and domain
user for us.
