### PR TITLE
converted nova to use repo_packages

### DIFF
--- a/rpc_deployment/inventory/group_vars/nova_all.yml
+++ b/rpc_deployment/inventory/group_vars/nova_all.yml
@@ -86,22 +86,6 @@ nova_scheduler_manager: nova.scheduler.manager.SchedulerManager
 nova_scheduler_max_attempts: 5
 nova_scheduler_weight_classes: nova.scheduler.weights.all_weighers
 
-## Git Source
-## ALL of this has been relocated to vars/repo_packages
-## TODO(someone) this should be removed once the repo bits are all figured out.
-git_repo: https://git.openstack.org/openstack/nova
-git_fallback_repo: https://github.com/openstack/nova
-git_etc_example: etc/nova/
-git_install_branch: master
-
-service_pip_dependencies:
-  - MySQL-python
-  - python-memcached
-  - pycrypto
-  - python-keystoneclient
-  - python-novaclient
-  - keystonemiddleware
-
 container_directories:
   - /var/log/nova
   - /var/lib/nova
@@ -111,9 +95,3 @@ container_directories:
   - /var/cache/nova
   - /var/lock/nova
   - /var/run/nova
-
-container_packages:
-  - libpq-dev
-  - open-iscsi
-  - vlan
-  - kpartx

--- a/rpc_deployment/playbooks/openstack/nova-all.yml
+++ b/rpc_deployment/playbooks/openstack/nova-all.yml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: nova-common.yml
 - include: nova-api-os-compute.yml
 - include: nova-api-ec2.yml
 - include: nova-api-metadata.yml

--- a/rpc_deployment/playbooks/openstack/nova-api-ec2.yml
+++ b/rpc_deployment/playbooks/openstack/nova-api-ec2.yml
@@ -30,13 +30,7 @@
 - hosts: nova_api_ec2
   user: root
   roles:
-    - common
-    - common_sudoers
-    - container_common
-    - openstack_common
-    - openstack_openrc
     - nova_common
-    - galera_client_cnf
     - init_script
   vars_files:
     - inventory/group_vars/nova_all.yml

--- a/rpc_deployment/playbooks/openstack/nova-api-os-compute.yml
+++ b/rpc_deployment/playbooks/openstack/nova-api-os-compute.yml
@@ -13,18 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: nova_all
-  user: root
-  roles:
-    - common
-    - common_sudoers
-    - container_common
-    - openstack_common
-    - openstack_openrc
-    - galera_client_cnf
-  vars_files:
-    - inventory/group_vars/nova_all.yml
-
 - hosts: nova_api_os_compute[0]
   user: root
   roles:

--- a/rpc_deployment/playbooks/openstack/nova-cert.yml
+++ b/rpc_deployment/playbooks/openstack/nova-cert.yml
@@ -16,13 +16,7 @@
 - hosts: nova_cert
   user: root
   roles:
-    - common
-    - common_sudoers
-    - container_common
-    - openstack_common
-    - openstack_openrc
     - nova_common
-    - galera_client_cnf
     - init_script
   vars_files:
     - inventory/group_vars/nova_all.yml

--- a/rpc_deployment/playbooks/openstack/nova-common.yml
+++ b/rpc_deployment/playbooks/openstack/nova-common.yml
@@ -13,14 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: nova_api_metadata
+- hosts: nova_all
   user: root
   roles:
-    - nova_common
-    - init_script
+    - common
+    - common_sudoers
+    - container_common
+    - openstack_common
+    - openstack_openrc
+    - galera_client_cnf
   vars_files:
     - inventory/group_vars/nova_all.yml
-    - vars/openstack_service_vars/nova_api_metadata.yml
-    - vars/openstack_service_vars/nova_spice_console_endpoint.yml
-  handlers:
-    - include: handlers/services.yml
+    - vars/repo_packages/nova.yml

--- a/rpc_deployment/playbooks/openstack/nova-compute.yml
+++ b/rpc_deployment/playbooks/openstack/nova-compute.yml
@@ -21,20 +21,15 @@
 - hosts: nova_compute
   user: root
   roles:
-    - common
-    - common_sudoers
     - container_extra_setup
     - neutron_add_network_interfaces
-    - container_common
-    - openstack_common
-    - openstack_openrc
     - nova_compute_devices
     - nova_common
     - nova_libvirt
-    - galera_client_cnf
     - init_script
   vars_files:
     - inventory/group_vars/nova_all.yml
+    - vars/repo_packages/nova_libvirt.yml
     - vars/config_vars/container_config_nova_compute.yml
     - vars/openstack_service_vars/nova_compute.yml
     - vars/openstack_service_vars/nova_spice_console_endpoint.yml

--- a/rpc_deployment/playbooks/openstack/nova-conductor.yml
+++ b/rpc_deployment/playbooks/openstack/nova-conductor.yml
@@ -16,13 +16,7 @@
 - hosts: nova_conductor
   user: root
   roles:
-    - common
-    - common_sudoers
-    - container_common
-    - openstack_common
-    - openstack_openrc
     - nova_common
-    - galera_client_cnf
     - init_script
   vars_files:
     - inventory/group_vars/nova_all.yml

--- a/rpc_deployment/playbooks/openstack/nova-scheduler.yml
+++ b/rpc_deployment/playbooks/openstack/nova-scheduler.yml
@@ -16,13 +16,7 @@
 - hosts: nova_scheduler
   user: root
   roles:
-    - common
-    - common_sudoers
-    - container_common
-    - openstack_common
-    - openstack_openrc
     - nova_common
-    - galera_client_cnf
     - init_script
   vars_files:
     - inventory/group_vars/nova_all.yml

--- a/rpc_deployment/playbooks/openstack/nova-spice-console.yml
+++ b/rpc_deployment/playbooks/openstack/nova-spice-console.yml
@@ -16,13 +16,7 @@
 - hosts: nova_spice_console
   user: root
   roles:
-    - common
-    - common_sudoers
-    - container_common
-    - openstack_common
-    - openstack_openrc
     - nova_common
-    - galera_client_cnf
     - init_script
   vars_files:
     - inventory/group_vars/nova_all.yml
@@ -34,13 +28,7 @@
 - hosts: nova_spice_console
   user: root
   roles:
-    - common
-    - common_sudoers
-    - container_common
-    - openstack_common
-    - openstack_openrc
     - nova_common
-    - galera_client_cnf
     - init_script
   vars_files:
     - vars/openstack_service_vars/nova_console_auth.yml

--- a/rpc_deployment/playbooks/openstack/openstack-common.yml
+++ b/rpc_deployment/playbooks/openstack/openstack-common.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: glance_all:heat_all:nova_all:cinder_all
+- hosts: glance_all:heat_all:cinder_all
   user: root
   roles:
     - common

--- a/rpc_deployment/roles/openstack_common/tasks/main.yml
+++ b/rpc_deployment/roles/openstack_common/tasks/main.yml
@@ -18,7 +18,12 @@
 
 # TODO(kevin) This should go away sooner than later
 - name: Laydown the example files
-  shell: >
-    chdir="/opt/{{ service_name }}_{{ git_install_branch | replace('/', '_') }}/{{ git_etc_example }}"
-    for i in *; do if [ ! -f "/etc/{{ service_name }}/$i" ]; then cp -R $i /etc/{{ service_name }}/; fi; done;
+  shell: |
+    for i in *; do 
+      if [ ! -f "/etc/{{ service_name }}/$i" ]; then 
+        cp -R $i /etc/{{ service_name }}/
+      fi
+    done
+  args:
+    chdir: "/opt/{{ service_name }}_{{ git_install_branch | replace('/', '_') }}/{{ git_etc_example }}"
   when: git_etc_example is defined


### PR DESCRIPTION
This PR converts nova to use the repo_packages/nova.yml variable for the installation of all of it's packages and removes all of the redundant tasks. 

Trello Card: https://trello.com/c/fZwGMlDy
