### PR TITLE
Add heat_stack_user role

### DIFF
--- a/rpc_deployment/roles/heat_common/tasks/heat_config.yml
+++ b/rpc_deployment/roles/heat_common/tasks/heat_config.yml
@@ -13,6 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# We add the keystone role used by heat to delegate to the heat service user
+# (for performing deferred operations via trusts)
+- name: Ensure stack_owner role
+  keystone: >
+    command=ensure_role
+    login_tenant_name="{{ auth_admin_tenant }}"
+    login_user="{{ auth_admin_username }}"
+    login_password="{{ auth_admin_password }}"
+    endpoint="{{ auth_admin_uri }}"
+    role_name="heat_stack_owner"
+
+# Any user creating stacks needs to have the 'heat_stack_owner' role assigned,
+# we add to admin user here for testing purposes
+- name: Ensure admin has stack_owner role
+  keystone: >
+    command=ensure_user_role
+    login_tenant_name="{{ auth_admin_tenant }}"
+    login_user="{{ auth_admin_username }}"
+    login_password="{{ auth_admin_password }}"
+    endpoint="{{ auth_admin_uri }}"
+    user_name="admin"
+    tenant_name="admin"
+    role_name="heat_stack_owner"
+
 - name: Setup Heat Config
   template: >
     src={{ item }}

--- a/rpc_deployment/roles/heat_domain_user/tasks/main.yml
+++ b/rpc_deployment/roles/heat_domain_user/tasks/main.yml
@@ -13,25 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Ensure stack_owner role
+# This is the role assigned to users created within Heat stacks themselves
+- name: Ensure stack_user role
   keystone: >
     command=ensure_role
     login_tenant_name="{{ auth_admin_tenant }}"
-    login_user="{{ auth_admin_username }}" 
+    login_user="{{ auth_admin_username }}"
     login_password="{{ auth_admin_password }}"
     endpoint="{{ auth_admin_uri }}"
-    role_name="heat_stack_owner"
-
-- name: Ensure admin has stack_owner role
-  keystone: >
-    command=ensure_user_role
-    login_tenant_name="{{ auth_admin_tenant }}"
-    login_user="{{ auth_admin_username }}" 
-    login_password="{{ auth_admin_password }}"
-    endpoint="{{ auth_admin_uri }}"
-    user_name="admin"
-    tenant_name="admin"
-    role_name="heat_stack_owner"
+    role_name="heat_stack_user"
 
 - name: Create heat domain and domain user
   shell: |


### PR DESCRIPTION
In issue #195 @miguelgrinberg points out that we need a heat_stack_user
role which is assigned to keystone users created by stacks themselves.
This change adds that user and also moves some of the tasks in the
heat_domain_user role to heat_common, where they are better suited.
