### PR TITLE
Convert heat to use repo_packages

### DIFF
--- a/rpc_deployment/inventory/group_vars/heat_all.yml
+++ b/rpc_deployment/inventory/group_vars/heat_all.yml
@@ -27,7 +27,6 @@ verbose: True
 container_lvm_fstype: ext4
 container_lvm_fssize: 5GB
 
-
 ## DB
 container_mysql_user: heat
 container_mysql_password: "{{ heat_container_mysql_password }}"
@@ -64,24 +63,6 @@ heat_watch_server_url: "http://{{ external_vip_address }}:8003"
 heat_waitcondition_server_url: "http://{{ internal_vip_address }}:8000/v1/waitcondition"
 heat_metadata_server_url: "http://{{ internal_vip_address }}:8000"
 
-## Git Source
-## ALL of this has been relocated to vars/repo_packages
-## TODO(someone) this should be removed once the repo bits are all figured out.
-git_repo: https://git.openstack.org/openstack/heat
-git_fallback_repo: https://github.com/openstack/heat
-git_etc_example: etc/heat
-git_install_branch: 93f3c78a8bd9ecb79fa3d719468b371e67519969
-
-service_pip_dependencies:
-  - MySQL-python
-  - python-memcached
-  - pycrypto
-  - python-heatclient
-  - python-keystoneclient
-  - python-troveclient
-  - python-ceilometerclient
-  - keystonemiddleware
-
 container_directories:
   - /etc/heat
   - /etc/heat/environment.d
@@ -89,7 +70,3 @@ container_directories:
   - /var/cache/heat
   - /var/lib/heat
   - /var/log/heat
-
-container_packages:
-  - rsync
-  - libxslt1.1 

--- a/rpc_deployment/playbooks/openstack/heat-api-cfn.yml
+++ b/rpc_deployment/playbooks/openstack/heat-api-cfn.yml
@@ -16,13 +16,7 @@
 - hosts: heat_api_cfn
   user: root
   roles:
-    - common
-    - common_sudoers
-    - container_common
     - heat_common
-    - openstack_common
-    - openstack_openrc
-    - galera_client_cnf
     - init_script
   vars_files:
     - vars/openstack_service_vars/heat_api_cfn.yml

--- a/rpc_deployment/playbooks/openstack/heat-api-cloudwatch.yml
+++ b/rpc_deployment/playbooks/openstack/heat-api-cloudwatch.yml
@@ -16,13 +16,7 @@
 - hosts: heat_api_cloudwatch
   user: root
   roles:
-    - common
-    - common_sudoers
-    - container_common
     - heat_common
-    - openstack_common
-    - openstack_openrc
-    - galera_client_cnf
     - init_script
   vars_files:
     - vars/openstack_service_vars/heat_api_cloudwatch.yml

--- a/rpc_deployment/playbooks/openstack/heat-api.yml
+++ b/rpc_deployment/playbooks/openstack/heat-api.yml
@@ -13,18 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: heat_all
-  user: root
-  roles:
-    - common
-    - common_sudoers
-    - container_common
-    - openstack_common
-    - openstack_openrc
-    - galera_client_cnf
-  vars_files:
-    - vars/openstack_service_vars/heat_api.yml
-
 - hosts: heat_api[0]
   user: root
   roles:

--- a/rpc_deployment/playbooks/openstack/heat-common.yml
+++ b/rpc_deployment/playbooks/openstack/heat-common.yml
@@ -13,8 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: heat-common.yml
-- include: heat-api.yml
-- include: heat-api-cfn.yml
-- include: heat-api-cloudwatch.yml
-- include: heat-engine.yml
+- hosts: heat_all
+  user: root
+  roles:
+    - common
+    - common_sudoers
+    - container_common
+    - openstack_common
+    - openstack_openrc
+    - galera_client_cnf
+  vars_files:
+    - vars/openstack_service_vars/heat_api.yml
+    - vars/repo_packages/heat.yml

--- a/rpc_deployment/playbooks/openstack/heat-engine.yml
+++ b/rpc_deployment/playbooks/openstack/heat-engine.yml
@@ -16,13 +16,7 @@
 - hosts: heat_engine
   user: root
   roles:
-    - common
-    - common_sudoers
-    - container_common
     - heat_common
-    - openstack_common
-    - openstack_openrc
-    - galera_client_cnf
     - init_script
   vars_files:
     - vars/openstack_service_vars/heat_engine.yml

--- a/rpc_deployment/playbooks/openstack/openstack-common.yml
+++ b/rpc_deployment/playbooks/openstack/openstack-common.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: glance_all:heat_all:cinder_all
+- hosts: glance_all:cinder_all
   user: root
   roles:
     - common

--- a/rpc_deployment/vars/repo_packages/heat.yml
+++ b/rpc_deployment/vars/repo_packages/heat.yml
@@ -21,6 +21,7 @@ repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}
 git_repo: https://git.openstack.org/openstack/heat
 git_fallback_repo: https://github.com/openstack/heat
 git_dest: "/opt/{{ repo_path }}"
+git_etc_example: etc/heat
 git_install_branch: master
 
 pip_wheel_name: heat


### PR DESCRIPTION
This change converts heat to use repo_packages.  Similar changes have
been done in nova / keystone in PRs #194 and #198 and will eventually
be applied to all OpenStack services that we deploy.
