### PR TITLE
Converted horizon to repo_packages

### DIFF
--- a/rpc_deployment/inventory/group_vars/horizon.yml
+++ b/rpc_deployment/inventory/group_vars/horizon.yml
@@ -52,11 +52,6 @@ container_directories:
   - "/etc/horizon"
   - "{{ install_lib_dir }}"
 
-service_pip_dependencies:
-  - MySQL-python
-  - python-memcached
-  - pycrypto
-
 horizon_fqdn: "{{ external_vip_address }}"
 horizon_server_name: "{{ container_name }}"
 horizon_self_signed: true


### PR DESCRIPTION
This finishes the conversion to repo_packages for horizon.

Trello Card: https://trello.com/c/8lLCJV4H
