### PR TITLE
Converted logstash to use repo_packages

### DIFF
--- a/rpc_deployment/inventory/group_vars/logstash.yml
+++ b/rpc_deployment/inventory/group_vars/logstash.yml
@@ -21,18 +21,3 @@ verbose: True
 
 container_lvm_fstype: ext4
 container_lvm_fssize: 5GB
-
-# Apt repos for ELK
-apt_container_keys:
-  - { url: "http://packages.elasticsearch.org/GPG-KEY-elasticsearch", state: "present" }
-
-apt_container_repos:
-  - { repo: "deb http://packages.elasticsearch.org/logstash/1.4/debian stable main", state: "present"}
-
-container_packages:
-  - logstash
-  - logstash-contrib
-
-service_pip_dependencies:
-  - python-memcached
-  - pycrypto

--- a/rpc_deployment/playbooks/infrastructure/logstash-install.yml
+++ b/rpc_deployment/playbooks/infrastructure/logstash-install.yml
@@ -13,19 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Setup supporting services
 - hosts: logstash
   user: root
   roles:
     - container_extra_setup
-  vars_files:
-    - vars/config_vars/container_config_logstash.yml
-
-
-- hosts: logstash
-  user: root
-  roles:
     - common
     - container_common
     - logging_common
     - logstash
+  vars_files:
+    - vars/repo_packages/logstash.yml
+    - vars/config_vars/container_config_logstash.yml

--- a/rpc_deployment/vars/repo_packages/logstash.yml
+++ b/rpc_deployment/vars/repo_packages/logstash.yml
@@ -26,3 +26,7 @@ container_packages:
   - logstash
   - logstash-contrib
   - openjdk-7-jre
+
+service_pip_dependencies:
+  - python-memcached
+  - pycrypto


### PR DESCRIPTION
This PR converts logstash to use repo_packages instead of group_vars.

Trello Card: https://trello.com/c/m7pf4M9Q
