### PR TITLE
Fix mariadb & galera install order

### DIFF
--- a/rpc_deployment/inventory/group_vars/galera.yml
+++ b/rpc_deployment/inventory/group_vars/galera.yml
@@ -20,18 +20,6 @@ container_lvm_fssize: 5GB
 
 debian_sys_maint_password: "{{ mysql_debian_sys_maint_password }}"
 
-mariadb_server_package: mariadb-galera-server-5.5
-
-galera_packages:
-  - mariadb-client
-  - "{{ mariadb_server_package }}"
-  - galera
-  - python-software-properties
-  - software-properties-common
-  - debconf-utils
-  - rsync
-  - xtrabackup
-
 # Size of the galera cache
 galera_gcache_size: 1G
 

--- a/rpc_deployment/vars/repo_packages/galera.yml
+++ b/rpc_deployment/vars/repo_packages/galera.yml
@@ -20,7 +20,10 @@ repo_package_name: galera
 # "galera_common" role.
 mariadb_server_package: "mariadb-galera-server-5.5"
 
-container_packages:
+# NB This is specifically galera_packages as these packages only get installed
+# during the galera play - this is because of the preseed task and the service
+# startup control used when installing mariadb-galera-server and galera.
+galera_packages:
   - mariadb-client
   - "{{ mariadb_server_package }}"
   - galera


### PR DESCRIPTION
- We were installing mariadb/galera as part of the galera play to ensure
  we could control the startup and preseed.
- This changes the play back to do this properly, instead of installing
  it as part of the "common" play.

Fixes-Bug: #222
