### PR TITLE
Install Tempest in utility container

### DIFF
--- a/rpc_deployment/library/glance
+++ b/rpc_deployment/library/glance
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCUMENTATION='''
+---
+module: glance
+short_description:
+    - Basic module for interacting with openstack glance
+description:
+    - Basic module for interacting with openstack glance
+options:
+    command:
+        description:
+            - Operation for the module to perform. Currently available
+        choices:
+            - image-list
+            - image-create
+    openrc_path:
+        decription:
+            - Path to openrc file from which credentials and keystoneclient
+            - endpoint will be extracted
+    image_name:
+        description:
+            - Name of the image to create
+    image_url:
+        description:
+            - URL from which to download the image data
+    image_container_format:
+        description:
+            - container format that the image uses (bare)
+    image_disk_format:
+        description:
+            - disk format that the image uses
+    image_is_public:
+        description:
+            - Should the image be visible to all tenants?
+        choices:
+            - true (public)
+            - flase (private)
+author: Hugh Saunders
+'''
+
+EXAMPLES = '''
+# Create an image
+- name: Ensure cirros image
+  glance:
+    command: 'image-create'
+    openrc_path: /root/openrc
+    image_name: cirros
+    image_url: 'https://launchpad.net/cirros/trunk/0.3.2/+download/cirros-0.3.2-source.tar.gz'
+    image_container_format: bare
+    image_disk_format: qcow2
+    image_is_public: True
+
+# Get facts about existing images
+- name: Get image facts
+  glance:
+    command: 'image-list'
+    openrc_path: /root/openrc
+'''
+
+import re
+import keystoneclient.v2_0.client as ksclient
+import glanceclient.v1.client as glclient
+
+COMMAND_MAP = {'image-list': 'list_images',
+               'image-create': 'create_image'}
+
+class ManageGlance(object):
+    def __init__(self, module):
+        self.state_change = False
+        self.glance = None
+        self.keystone = None
+        self.module = module
+        try:
+            self._keystone_authenticate()
+            self._init_glance()
+        except Exception as e:
+            self.module.fail_json(
+                err="Initialisation Error: %s" % e,
+                rc=2, msg=str(e))
+
+    def _parse_openrc(self):
+        """ Get credentials from an openrc file """
+        openrc_path = self.module.params['openrc_path']
+        line_re = re.compile('^export (?P<key>OS_\w*)=(?P<value>[^\n]*)')
+        with open(openrc_path) as openrc:
+            matches = [line_re.match(l) for l in openrc]
+            return dict(
+                (g.groupdict()['key'], g.groupdict()['value'])
+                    for g in matches if g)
+
+    def _keystone_authenticate(self):
+        """ Authenticate with Keystone """
+        openrc = self._parse_openrc()
+        self.keystone = ksclient.Client(username=openrc['OS_USERNAME'],
+                                        password=openrc['OS_PASSWORD'],
+                                        tenant_name=openrc['OS_TENANT_NAME'],
+                                        auth_url=openrc['OS_AUTH_URL'])
+
+    def _init_glance(self):
+        """ Create glance client object using token and url from keystone """
+        self.glance = glclient.Client(
+            version='1',
+            endpoint=self.keystone.service_catalog.url_for(
+                service_type='image'),
+            token=self.keystone.get_token(self.keystone.session))
+
+    def route(self):
+        """ Run the command specified by the command parameter """
+        getattr(self, COMMAND_MAP[self.module.params['command']])()
+
+    def _get_image_facts(self):
+        """ Helper function to format image list as a dictionary """
+        return dict((i.name, i.to_dict()) for i in self.glance.images.list())
+
+    def list_images(self):
+        """ Get information about available glance images and return
+        as a fact dictionary glance_iamges
+        """
+        self.module.exit_json(
+            changed=self.state_change,
+            ansible_facts=dict(glance_images=self._get_image_facts()))
+
+    def create_image(self):
+        """ Create a glance image that references a remote url """
+        p = self.module.params
+        name = p['image_name']
+        images = {i.name for i in self.glance.images.list()}
+        if name in images:
+            self.module.exit_json(changed=self.state_change,
+                ansible_facts=dict(glance_images=self._get_image_facts()))
+        else:
+            self.glance.images.create(name=name,
+                                 is_public=p['image_is_public'],
+                                 disk_format=p['image_disk_format'],
+                                 container_format=p['image_container_format'],
+                                 copy_from=p['image_url'])
+            self.state_change = True
+            self.module.exit_json(
+                changed=self.state_change,
+                ansible_facts=dict(glance_images=self._get_image_facts()))
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            command=dict(required=True, choices=COMMAND_MAP.keys()),
+            openrc_path=dict(required=True),
+            image_name=dict(required=False),
+            image_url=dict(required=False),
+            image_container_format=dict(required=False),
+            image_disk_format=dict(required=False),
+            image_is_public=dict(required=False, choices=BOOLEANS)
+        ),
+        supports_check_mode=False
+    )
+    mg = ManageGlance(module)
+    mg.route()
+
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()
+

--- a/rpc_deployment/playbooks/openstack/tempest.yml
+++ b/rpc_deployment/playbooks/openstack/tempest.yml
@@ -13,19 +13,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-repo_package_name: tempest
+# Configure tempest on the utility containers
 
-repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
+- hosts: utility_all
+  vars:
+    service_name: tempest
+  vars_files:
+    - vars/repo_packages/tempest.yml
+  roles:
+    - common
+    - openstack_common
+    - openstack_openrc
 
-## Git Source
-git_repo: https://git.openstack.org/openstack/tempest
-git_fallback_repo: https://github.com/openstack/tempest
-git_dest: "/opt/{{ repo_path }}"
-git_install_branch: 9d7d28b66f9aa3fe1220f418cc2d13dd19984429
+# Openstack resources only need to be created once
+- hosts: utility_all[0]
+  roles:
+    - tempest_resources
 
-pip_wheel_name: tempest
+# Tempest is installed and configured in all utility containers
+- hosts: utility_all
+  vars_files:
+    - vars/repo_packages/tempest.yml
+  roles:
+    - tempest
 
-service_pip_dependencies:
-  - nose
-  - testrepository
-  - testtools
+

--- a/rpc_deployment/roles/tempest/files/rpc_tempest_gate.sh
+++ b/rpc_deployment/roles/tempest/files/rpc_tempest_gate.sh
@@ -1,4 +1,4 @@
----
+#!/usr/bin/env bash
 # Copyright 2014, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,19 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-repo_package_name: tempest
+# Script for running gate tests. Initially very sparse
+# additional projects and test types will be added over time.
 
-repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
+set -e
+set -x
 
-## Git Source
-git_repo: https://git.openstack.org/openstack/tempest
-git_fallback_repo: https://github.com/openstack/tempest
-git_dest: "/opt/{{ repo_path }}"
-git_install_branch: 9d7d28b66f9aa3fe1220f418cc2d13dd19984429
+API_TESTS="identity"
 
-pip_wheel_name: tempest
+pushd /opt/tempest_*
+source /root/openrc
 
-service_pip_dependencies:
-  - nose
-  - testrepository
-  - testtools
+for project in $API_TESTS
+do
+  echo "Running API tests for $project"
+  nosetests -v tempest/api/$project
+done
+
+popd
+echo "GATE PASS"
+

--- a/rpc_deployment/roles/tempest/tasks/main.yml
+++ b/rpc_deployment/roles/tempest/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Get admin tenant id
+  keystone:
+    command: get_tenant
+    tenant_name: admin
+    endpoint: "{{ auth_identity_uri }}"
+    login_tenant_name: "{{ auth_admin_tenant }}"
+    login_user: "{{ auth_admin_username }}"
+    login_password: "{{ auth_admin_password }}"
+
+- name: Store admin tenant id
+  set_fact:
+    keystone_admin_tenant_id: "{{ keystone_facts.id }}"
+
+- name: Create tempest lock dir
+  file:
+    path: "/opt/{{ repo_path }}/locks"
+    state: directory
+
+- name: Template tempest config
+  template:
+    src: tempest.conf.j2
+    dest: "/opt/{{ repo_path }}/etc/tempest.conf"
+
+- name: Drop tempest script
+  copy:
+    src: rpc_tempest_gate.sh
+    dest: /root/rpc_tempest_gate.sh
+
+- name: Set attributes for tempest script
+  file:
+    path: /root/rpc_tempest_gate.sh
+    mode: 0755

--- a/rpc_deployment/roles/tempest/templates/tempest.conf.j2
+++ b/rpc_deployment/roles/tempest/templates/tempest.conf.j2
@@ -1,0 +1,161 @@
+[DEFAULT]
+debug = True
+log_file = tempest.log
+use_stderr = False
+lock_path = /opt/{{ repo_path }}/locks
+
+[auth]
+
+[boto]
+ssh_user = cirros
+instance_type = m1.nano
+aki_manifest = cirros-0.3.2-x86_64-vmlinuz.manifest.xml
+ami_manifest = cirros-0.3.2-x86_64-blank.img.manifest.xml
+ari_manifest = cirros-0.3.2-x86_64-initrd.manifest.xml
+s3_materials_path = /opt/stack/devstack/files/images/s3-materials/cirros-0.3.2
+s3_url = http://134.213.136.181:3333
+ec2_url = http://134.213.136.181:8773/services/Cloud
+http_socket_timeout = 30
+build_timeout = 196
+
+[cli]
+cli_dir = /usr/local/bin
+has_manage=false
+
+
+
+[compute]
+ssh_connect_method = fixed
+flavor_ref_alt = 3
+flavor_ref = 2
+image_alt_ssh_user = cirros
+image_ref_alt = {{ hostvars[groups['utility_all'][0]]['glance_images']['cirros']['id'] }}
+image_ssh_user = cirros
+image_ref = {{ hostvars[groups['utility_all'][0]]['glance_images']['cirros']['id'] }}
+ssh_timeout = 196
+ip_version_for_ssh = 4
+network_for_ssh = private
+ssh_user = cirros
+allow_tenant_isolation = True
+build_timeout = 196
+
+[compute-admin]
+tenant_name = {{ auth_admin_tenant }}
+password = {{ auth_admin_password }}
+username = {{ auth_admin_username }}
+
+[compute-feature-enabled]
+api_v3_extensions = all
+api_extensions = all
+block_migration_for_live_migration = False
+change_password = False
+live_migration = False
+resize = True
+api_v3 = False
+
+
+[dashboard]
+login_url = http://{{ external_vip_address }}/auth/login/
+dashboard_url = http://{{ external_vip_address }}/
+
+
+[identity]
+auth_version = v2
+admin_domain_name = Default
+admin_tenant_id = {{ keystone_admin_tenant_id }}
+admin_tenant_name = {{ auth_admin_tenant }}
+admin_password = {{ auth_admin_password }}
+admin_username = {{ auth_admin_username }}
+alt_tenant_name = alt_demo
+alt_password = alt_demo
+alt_username = alt_demo
+tenant_name = demo
+password = demo
+username = demo
+uri_v3 = http://{{ external_vip_address }}:5000/v3/
+uri = http://{{ external_vip_address }}:5000/v2.0/
+
+
+
+[identity-feature-enabled]
+
+[image]
+
+
+[image-feature-enabled]
+[input-scenario]
+[negative]
+
+[network]
+default_network = 10.0.0.0/24
+public_router_id =
+public_network_id =
+tenant_networks_reachable = false
+api_version = 2.0
+
+[network-feature-enabled]
+api_extensions = all
+ipv6_subnet_attributes = True
+ipv6 = True
+
+[object-storage]
+
+
+
+[object-storage-feature-enabled]
+discoverable_apis = all
+
+
+[orchestration]
+build_timeout = 900
+instance_type = m1.heat
+image_ref = Fedora-x86_64-20-20140618-sda
+
+[queuing]
+[scenario]
+large_ops_number = 0
+aki_img_file = cirros-0.3.2-x86_64-vmlinuz
+ari_img_file = cirros-0.3.2-x86_64-initrd
+ami_img_file = cirros-0.3.2-x86_64-blank.img
+img_dir = /opt/stack/devstack/files/images/cirros-0.3.2-x86_64-uec
+
+[service_available]
+neutron = True
+heat = True
+ceilometer = False
+swift = False
+cinder = True
+nova = True
+glance = True
+horizon = True
+sahara = False
+ironic = False
+
+[stress]
+
+
+[telemetry]
+too_slow_to_test = False
+
+
+[volume]
+build_timeout = 196
+
+
+[volume-feature-enabled]
+backup = False
+api_extensions = all
+
+
+[compute-feature-disabled]
+api_v3_extensions =
+api_extensions =
+
+[network-feature-disabled]
+api_extensions =
+
+[object-storage-feature-disabled]
+discoverable_apis =
+
+[volume-feature-disabled]
+api_extensions =

--- a/rpc_deployment/roles/tempest_resources/tasks/main.yml
+++ b/rpc_deployment/roles/tempest_resources/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Ensure cirros image
+  glance:
+    command: 'image-create'
+    openrc_path: /root/openrc
+    image_name: cirros
+    image_url: 'https://launchpad.net/cirros/trunk/0.3.2/+download/cirros-0.3.2-source.tar.gz'
+    image_container_format: bare
+    image_disk_format: qcow2
+    image_is_public: True
+
+- name: Ensure tempest tenants
+  keystone:
+    command: ensure_tenant
+    tenant_name: "{{ item }}"
+    description: "{{ item }} Tenant"
+    endpoint: "{{ auth_identity_uri }}"
+    login_tenant_name: "{{ auth_admin_tenant }}"
+    login_user: "{{ auth_admin_username }}"
+    login_password: "{{ auth_admin_password }}"
+  with_items:
+    - demo
+    - alt_demo


### PR DESCRIPTION
- Tempest playbook added to openstack dir
- glance_image module added for creating images and gathering image
  facts
- tempest_resources role added to create tempest prerequisites (cirros
  image, tenants)
- tempest role added for configuring tempest
- rpc_tempest_gate.sh added to /root in utility containers
