### PR TITLE
Move duplicated glance roles into a common file.

### DIFF
--- a/rpc_deployment/playbooks/openstack/glance-all.yml
+++ b/rpc_deployment/playbooks/openstack/glance-all.yml
@@ -13,5 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: glance-common.yml
 - include: glance-api.yml
 - include: glance-registry.yml

--- a/rpc_deployment/playbooks/openstack/glance-api.yml
+++ b/rpc_deployment/playbooks/openstack/glance-api.yml
@@ -13,18 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: glance_all
-  user: root
-  roles:
-    - common
-    - common_sudoers
-    - container_common
-    - openstack_common
-    - openstack_openrc
-    - galera_client_cnf
-  vars_files:
-    - vars/openstack_service_vars/glance_api.yml
-
 - hosts: glance_api[0]
   user: root
   roles:

--- a/rpc_deployment/playbooks/openstack/glance-common.yml
+++ b/rpc_deployment/playbooks/openstack/glance-common.yml
@@ -13,13 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This playbook deploys Glance-Registry.
-- hosts: glance_registry
+- hosts: glance_all
   user: root
   roles:
-    - glance_common
-    - init_script
+    - common
+    - common_sudoers
+    - container_common
+    - openstack_common
+    - openstack_openrc
+    - galera_client_cnf
   vars_files:
-    - vars/openstack_service_vars/glance_registry.yml
-  handlers:
-    - include: handlers/services.yml
+    - vars/repo_packages/glance.yml
+    - vars/openstack_service_vars/glance_api.yml


### PR DESCRIPTION
This change reduces some duplication, and ensures that glance is using the right repo_packages variable file.
