### PR TITLE
added check to make sure that the volume group variable exists since the variable is needed for cinder lvm but not netapp

### DIFF
--- a/rpc_deployment/roles/cinder_device_add/tasks/device_add.yml
+++ b/rpc_deployment/roles/cinder_device_add/tasks/device_add.yml
@@ -28,5 +28,5 @@
       done
     fi
   with_items: cinder_backends|dictsort
-  when: cinder_backends is defined and is_metal != true
+  when: cinder_backends is defined and is_metal != true and cinder_backends[item.0]['volume_group'] is defined
   delegate_to: "{{ physical_host }}"


### PR DESCRIPTION
(cherry picked from commit 55d3cc09f3f4470b2e6ea82a6286b1336f83a9e6)

Backport to fix rcbops/ansible-lxc-rpc#165
