### PR TITLE
Bumped version for Juno heat deps

### DIFF
--- a/rpc_deployment/vars/repo_packages/python_glanceclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_glanceclient.yml
@@ -19,6 +19,6 @@ repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 git_repo: "https://git.openstack.org/openstack/python-glanceclient"
 git_fallback_repo: "https://github.com/openstack/python-glanceclient"
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: 0.13.1
+git_install_branch: 0.14.1
 
 pip_wheel_name: python-glanceclient

--- a/rpc_deployment/vars/repo_packages/python_saharaclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_saharaclient.yml
@@ -19,6 +19,6 @@ repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 git_repo: "https://git.openstack.org/openstack/python-saharaclient"
 git_fallback_repo: "https://github.com/openstack/python-saharaclient"
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: 0.7.1
+git_install_branch: 0.7.4
 
 pip_wheel_name: python-saharaclient


### PR DESCRIPTION
This PR bumps the version of the clients built. This is a Juno dependency issue. The respective wheels have been built and uploaded to [ http://rpc-slushee.rackspace.com/python_packages/10.0.0/ ].

Fixes Issue: https://github.com/rcbops/ansible-lxc-rpc/issues/233
