### PR TITLE
This change moves the SHA for openstack global requirements.

### DIFF
--- a/rpc_deployment/vars/repo_packages/openstack_global_requirements.yml
+++ b/rpc_deployment/vars/repo_packages/openstack_global_requirements.yml
@@ -19,7 +19,7 @@ repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 git_repo: "https://git.openstack.org/openstack/requirements"
 git_fallback_repo: "https://github.com/openstack/requirements"
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: c99cbdc7d3a1e5f5b29b9f1507fad2e62e09485c
+git_install_branch: c312e42b9170172f4a8be5aadf0e4d4dae88b22b
 requirements_file: global-requirements.txt
 
 pip_wheel_name: requirements


### PR DESCRIPTION
The reason for this change is to update python package versions.
@miguelgrinberg found that an upstream commit in global requirements
was made to ensure nova is not 100% broken, IE: commit message
"block sqlalchemy migrate 0.9.2 as it breaks all of nova".

Reason for change : https://github.com/openstack/requirements/commit/c312e42b9170172f4a8be5aadf0e4d4dae88b22b
