### PR TITLE
track proposed/juno branches for openstack projects

### DIFF
--- a/rpc_deployment/vars/repo_packages/cinder.yml
+++ b/rpc_deployment/vars/repo_packages/cinder.yml
@@ -21,7 +21,7 @@ repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}
 git_repo: https://git.openstack.org/openstack/cinder
 git_fallback_repo: https://github.com/openstack/cinder
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: master
+git_install_branch: proposed/juno
 
 pip_wheel_name: cinder
 

--- a/rpc_deployment/vars/repo_packages/glance.yml
+++ b/rpc_deployment/vars/repo_packages/glance.yml
@@ -21,7 +21,7 @@ repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}
 git_repo: https://git.openstack.org/openstack/glance
 git_fallback_repo: https://github.com/openstack/glance
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: master
+git_install_branch: proposed/juno
 
 pip_wheel_name: glance
 

--- a/rpc_deployment/vars/repo_packages/heat.yml
+++ b/rpc_deployment/vars/repo_packages/heat.yml
@@ -22,7 +22,7 @@ git_repo: https://git.openstack.org/openstack/heat
 git_fallback_repo: https://github.com/openstack/heat
 git_dest: "/opt/{{ repo_path }}"
 git_etc_example: etc/heat
-git_install_branch: master
+git_install_branch: proposed/juno
 
 pip_wheel_name: heat
 

--- a/rpc_deployment/vars/repo_packages/horizon.yml
+++ b/rpc_deployment/vars/repo_packages/horizon.yml
@@ -21,7 +21,7 @@ repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}
 git_repo: https://git.openstack.org/openstack/horizon
 git_fallback_repo: https://github.com/openstack/horizon
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: master
+git_install_branch: proposed/juno
 
 pip_wheel_name: horizon
 

--- a/rpc_deployment/vars/repo_packages/keystone.yml
+++ b/rpc_deployment/vars/repo_packages/keystone.yml
@@ -22,7 +22,7 @@ git_repo: https://git.openstack.org/openstack/keystone
 git_fallback_repo: https://github.com/openstack/keystone
 git_dest: "/opt/{{ repo_path }}"
 git_etc_example: etc/
-git_install_branch: master
+git_install_branch: proposed/juno
 
 pip_wheel_name: keystone
 

--- a/rpc_deployment/vars/repo_packages/neutron.yml
+++ b/rpc_deployment/vars/repo_packages/neutron.yml
@@ -22,7 +22,7 @@ git_repo: https://git.openstack.org/openstack/neutron
 git_fallback_repo: https://github.com/openstack/neutron
 git_dest: "/opt/{{ repo_path }}"
 git_etc_example: etc/
-git_install_branch: master
+git_install_branch: proposed/juno
 pip_wheel_name: neutron
 
 container_packages:

--- a/rpc_deployment/vars/repo_packages/nova.yml
+++ b/rpc_deployment/vars/repo_packages/nova.yml
@@ -22,7 +22,7 @@ git_repo: https://git.openstack.org/openstack/nova
 git_fallback_repo: https://github.com/openstack/nova
 git_dest: "/opt/{{ repo_path }}"
 git_etc_example: etc/nova/
-git_install_branch: master
+git_install_branch: proposed/juno
 
 pip_wheel_name: nova
 


### PR DESCRIPTION
until stable/juno is cut, we need to track the head of the proposed/juno branches for each openstack project, because master will now be open for kilo features
