### PR TITLE
Fix glance vars duplication in group_vars/repo_packages

### DIFF
--- a/rpc_deployment/inventory/group_vars/glance_all.yml
+++ b/rpc_deployment/inventory/group_vars/glance_all.yml
@@ -70,23 +70,6 @@ service_names:
 
 flavor: "keystone+cachemanagement"
 
-## Git Source
-## ALL of this has been relocated to vars/repo_packages
-## TODO(someone) this should be removed once the repo bits are all figured out.
-git_repo: https://git.openstack.org/openstack/glance
-git_fallback_repo: https://github.com/openstack/glance
-git_etc_example: etc/
-git_install_branch: master
-
-service_pip_dependencies:
-  - warlock
-  - MySQL-python
-  - python-memcached
-  - pycrypto
-  - python-glanceclient
-  - python-keystoneclient
-  - keystonemiddleware
-
 container_directories:
   - /var/log/glance
   - /var/lib/glance

--- a/rpc_deployment/vars/repo_packages/glance.yml
+++ b/rpc_deployment/vars/repo_packages/glance.yml
@@ -22,6 +22,7 @@ git_repo: https://git.openstack.org/openstack/glance
 git_fallback_repo: https://github.com/openstack/glance
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: proposed/juno
+git_etc_example: etc/
 
 pip_wheel_name: glance
 


### PR DESCRIPTION
- Git vars and service_pip_dependencies were duplicated
- Fixes inconsistencies when the vars aren't the same
- Remove duplicate vars from group_vars
- Ensure all vars are in repo_packages

Fixes-Bug: #240
