### PR TITLE
Flip flopped all of the git repos

### DIFF
--- a/rpc_deployment/vars/repo_packages/cinder.yml
+++ b/rpc_deployment/vars/repo_packages/cinder.yml
@@ -18,8 +18,8 @@ repo_package_name: cinder
 repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/cinder
-git_fallback_repo: https://github.com/openstack/cinder
+git_repo: https://github.com/openstack/cinder
+git_fallback_repo: https://git.openstack.org/openstack/cinder
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: master
 

--- a/rpc_deployment/vars/repo_packages/glance.yml
+++ b/rpc_deployment/vars/repo_packages/glance.yml
@@ -18,8 +18,8 @@ repo_package_name: glance
 repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/glance
-git_fallback_repo: https://github.com/openstack/glance
+git_repo: https://github.com/openstack/glance
+git_fallback_repo: https://git.openstack.org/openstack/glance
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: master
 

--- a/rpc_deployment/vars/repo_packages/heat.yml
+++ b/rpc_deployment/vars/repo_packages/heat.yml
@@ -18,8 +18,8 @@ repo_package_name: heat
 repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/heat
-git_fallback_repo: https://github.com/openstack/heat
+git_repo: https://github.com/openstack/heat
+git_fallback_repo: https://git.openstack.org/openstack/heat
 git_dest: "/opt/{{ repo_path }}"
 git_etc_example: etc/heat
 git_install_branch: master

--- a/rpc_deployment/vars/repo_packages/horizon.yml
+++ b/rpc_deployment/vars/repo_packages/horizon.yml
@@ -18,8 +18,8 @@ repo_package_name: horizon
 repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/horizon
-git_fallback_repo: https://github.com/openstack/horizon
+git_repo: https://github.com/openstack/horizon
+git_fallback_repo: https://git.openstack.org/openstack/horizon
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: master
 

--- a/rpc_deployment/vars/repo_packages/keystone.yml
+++ b/rpc_deployment/vars/repo_packages/keystone.yml
@@ -18,8 +18,8 @@ repo_package_name: keystone
 repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/keystone
-git_fallback_repo: https://github.com/openstack/keystone
+git_repo: https://github.com/openstack/keystone
+git_fallback_repo: https://git.openstack.org/openstack/keystone
 git_dest: "/opt/{{ repo_path }}"
 git_etc_example: etc/
 git_install_branch: master

--- a/rpc_deployment/vars/repo_packages/keystonemiddleware.yml
+++ b/rpc_deployment/vars/repo_packages/keystonemiddleware.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/keystonemiddleware
-git_fallback_repo: https://github.com/openstack/keystonemiddleware
+git_repo: https://github.com/openstack/keystonemiddleware
+git_fallback_repo: https://git.openstack.org/openstack/keystonemiddleware
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: master
 

--- a/rpc_deployment/vars/repo_packages/neutron.yml
+++ b/rpc_deployment/vars/repo_packages/neutron.yml
@@ -18,8 +18,8 @@ repo_package_name: neutron
 repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/neutron
-git_fallback_repo: https://github.com/openstack/neutron
+git_repo: https://github.com/openstack/neutron
+git_fallback_repo: https://git.openstack.org/openstack/neutron
 git_dest: "/opt/{{ repo_path }}"
 git_etc_example: etc/
 git_install_branch: master

--- a/rpc_deployment/vars/repo_packages/nova.yml
+++ b/rpc_deployment/vars/repo_packages/nova.yml
@@ -18,8 +18,8 @@ repo_package_name: nova
 repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/nova
-git_fallback_repo: https://github.com/openstack/nova
+git_repo: https://github.com/openstack/nova
+git_fallback_repo: https://git.openstack.org/openstack/nova
 git_dest: "/opt/{{ repo_path }}"
 git_etc_example: etc/nova/
 git_install_branch: master

--- a/rpc_deployment/vars/repo_packages/nova_libvirt.yml
+++ b/rpc_deployment/vars/repo_packages/nova_libvirt.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-container_packages::
+container_packages:
   - libvirt-bin
   - python-libvirt
   - qemu

--- a/rpc_deployment/vars/repo_packages/openstack_global_requirements.yml
+++ b/rpc_deployment/vars/repo_packages/openstack_global_requirements.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/requirements"
-git_fallback_repo: "https://github.com/openstack/requirements"
+git_repo: https://github.com/openstack/requirements
+git_fallback_repo: https://git.openstack.org/openstack/requirements
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: master
 requirements_file: global-requirements.txt

--- a/rpc_deployment/vars/repo_packages/python_barbicanclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_barbicanclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-barbicanclient"
-git_fallback_repo: "https://github.com/openstack/python-barbicanclient"
+git_repo: https://github.com/openstack/python-barbicanclient
+git_fallback_repo: https://git.openstack.org/openstack/python-barbicanclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 2.2.1
 

--- a/rpc_deployment/vars/repo_packages/python_ceilometerclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_ceilometerclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-ceilometerclient"
-git_fallback_repo: "https://github.com/openstack/python-ceilometerclient"
+git_repo: https://github.com/openstack/python-ceilometerclient
+git_fallback_repo: https://git.openstack.org/openstack/python-ceilometerclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 1.0.9
 

--- a/rpc_deployment/vars/repo_packages/python_cinderclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_cinderclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-cinderclient"
-git_fallback_repo: "https://github.com/openstack/python-cinderclient"
+git_repo: https://github.com/openstack/python-cinderclient
+git_fallback_repo: https://git.openstack.org/openstack/python-cinderclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 1.0.9
 

--- a/rpc_deployment/vars/repo_packages/python_designateclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_designateclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-designateclient"
-git_fallback_repo: "https://github.com/openstack/python-designateclient"
+git_repo: https://github.com/openstack/python-designateclient
+git_fallback_repo: https://git.openstack.org/openstack/python-designateclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 1.0.3
 

--- a/rpc_deployment/vars/repo_packages/python_glanceclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_glanceclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-glanceclient"
-git_fallback_repo: "https://github.com/openstack/python-glanceclient"
+git_repo: https://github.com/openstack/python-glanceclient
+git_fallback_repo: https://git.openstack.org/openstack/python-glanceclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 0.13.1
 

--- a/rpc_deployment/vars/repo_packages/python_heatclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_heatclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-heatclient"
-git_fallback_repo: "https://github.com/openstack/python-heatclient"
+git_repo: https://github.com/openstack/python-heatclient
+git_fallback_repo: https://git.openstack.org/openstack/python-heatclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 0.2.10
 

--- a/rpc_deployment/vars/repo_packages/python_ironicclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_ironicclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-ironicclient"
-git_fallback_repo: "https://github.com/openstack/python-ironicclient"
+git_repo: https://github.com/openstack/python-ironicclient
+git_fallback_repo: https://git.openstack.org/openstack/python-ironicclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 0.2.1
 

--- a/rpc_deployment/vars/repo_packages/python_keystoneclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_keystoneclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-keystoneclient"
-git_fallback_repo: "https://github.com/openstack/python-keystoneclient"
+git_repo: https://github.com/openstack/python-keystoneclient
+git_fallback_repo: https://git.openstack.org/openstack/python-keystoneclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 0.10.1
 

--- a/rpc_deployment/vars/repo_packages/python_neutronclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_neutronclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-neutronclient"
-git_fallback_repo: "https://github.com/openstack/python-neutronclient"
+git_repo: https://github.com/openstack/python-neutronclient
+git_fallback_repo: https://git.openstack.org/openstack/python-neutronclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 2.3.6
 

--- a/rpc_deployment/vars/repo_packages/python_novaclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_novaclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-novaclient"
-git_fallback_repo: "https://github.com/openstack/python-novaclient"
+git_repo: https://github.com/openstack/python-novaclient
+git_fallback_repo: https://git.openstack.org/openstack/python-novaclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 2.18.1
 

--- a/rpc_deployment/vars/repo_packages/python_openstackclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_openstackclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-openstackclient"
-git_fallback_repo: "https://github.com/openstack/python-openstackclient"
+git_repo: https://github.com/openstack/python-openstackclient
+git_fallback_repo: https://git.openstack.org/openstack/python-openstackclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 0.4.0
 

--- a/rpc_deployment/vars/repo_packages/python_saharaclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_saharaclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-saharaclient"
-git_fallback_repo: "https://github.com/openstack/python-saharaclient"
+git_repo: https://github.com/openstack/python-saharaclient
+git_fallback_repo: https://git.openstack.org/openstack/python-saharaclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 0.7.1
 

--- a/rpc_deployment/vars/repo_packages/python_swiftclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_swiftclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-swiftclient"
-git_fallback_repo: "https://github.com/openstack/python-swiftclient"
+git_repo: https://github.com/openstack/python-swiftclient
+git_fallback_repo: https://git.openstack.org/openstack/python-swiftclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 2.2.0
 

--- a/rpc_deployment/vars/repo_packages/python_troveclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_troveclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-troveclient"
-git_fallback_repo: "https://github.com/openstack/python-troveclient"
+git_repo: https://github.com/openstack/python-troveclient
+git_fallback_repo: https://git.openstack.org/openstack/python-troveclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 1.0.5
 

--- a/rpc_deployment/vars/repo_packages/python_tuskarclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_tuskarclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-tuskarclient"
-git_fallback_repo: "https://github.com/openstack/python-tuskarclient"
+git_repo: https://github.com/openstack/python-tuskarclient
+git_fallback_repo: https://git.openstack.org/openstack/python-tuskarclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 0.1.8
 

--- a/rpc_deployment/vars/repo_packages/python_zaqarclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_zaqarclient.yml
@@ -16,8 +16,8 @@
 repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: "https://git.openstack.org/openstack/python-zaqarclient"
-git_fallback_repo: "https://github.com/openstack/python-zaqarclient"
+git_repo: https://github.com/openstack/python-zaqarclient
+git_fallback_repo: https://git.openstack.org/openstack/python-zaqarclient
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: 0.0.2
 

--- a/rpc_deployment/vars/repo_packages/swift.yml
+++ b/rpc_deployment/vars/repo_packages/swift.yml
@@ -18,8 +18,8 @@ repo_package_name: swift
 repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/swift
-git_fallback_repo: https://github.com/openstack/swift
+git_repo: https://github.com/openstack/swift
+git_fallback_repo: https://git.openstack.org/openstack/swift
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: master
 

--- a/rpc_deployment/vars/repo_packages/tempest.yml
+++ b/rpc_deployment/vars/repo_packages/tempest.yml
@@ -18,8 +18,8 @@ repo_package_name: tempest
 repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
-git_repo: https://git.openstack.org/openstack/tempest
-git_fallback_repo: https://github.com/openstack/tempest
+git_repo: https://github.com/openstack/tempest
+git_fallback_repo: https://git.openstack.org/openstack/tempest
 git_dest: "/opt/{{ repo_path }}"
 git_install_branch: master
 


### PR DESCRIPTION
On all of our projects were were depending on git.openstack.org to be
always available and the definitive source for all of our git repos.
Sadly git.openstack.org has frequent timeouts and has proven itself to
be unpredictable. To aid in deployments and ensure better overall
deployment performance all of the project git repos have been flip
flipped. Now github.com/openstack will be used for all clone operations
as the primary git repository and if there are issues with github we will
fall back to git.openstack.org.

Resolves Issue: https://github.com/rcbops/ansible-lxc-rpc/issues/188
Related Issue: https://github.com/rcbops/ansible-lxc-rpc/pull/163
