### PR TITLE
Use openstack cli instead of heat-keystone-setup-domain

### DIFF
--- a/rpc_deployment/inventory/group_vars/all.yml
+++ b/rpc_deployment/inventory/group_vars/all.yml
@@ -139,6 +139,7 @@ auth_admin_password: "{{ keystone_auth_admin_password }}"
 auth_admin_token: "{{ keystone_auth_admin_password }}"
 auth_admin_tenant: admin
 auth_identity_uri: "http://{{ internal_vip_address }}:5000/v2.0"
+auth_identity_uri_v3: "http://{{ internal_vip_address }}:5000/v3"
 auth_admin_uri: "http://{{ internal_vip_address }}:35357/v2.0"
 auth_host: "{{ internal_vip_address }}"
 auth_port: 35357

--- a/rpc_deployment/inventory/group_vars/heat_all.yml
+++ b/rpc_deployment/inventory/group_vars/heat_all.yml
@@ -53,7 +53,7 @@ service_names:
 
 ## Stack 
 stack_domain_admin_password: "{{ heat_stack_domain_admin_password }}"
-stack_domain_admin: heat_domain_admin
+stack_domain_admin: stack_domain_admin
 stack_user_domain_name: heat
 deferred_auth_method: trusts
 

--- a/rpc_deployment/roles/heat_domain_user/tasks/main.yml
+++ b/rpc_deployment/roles/heat_domain_user/tasks/main.yml
@@ -23,15 +23,33 @@
     endpoint="{{ auth_admin_uri }}"
     role_name="heat_stack_user"
 
-- name: Create heat domain and domain user
+- name: Create heat domain
   shell: |
     . /root/openrc
-    /usr/local/bin/heat-keystone-setup-domain --stack-domain-admin {{ stack_domain_admin }} \
-                                              --stack-domain-admin-password {{ stack_domain_admin_password }} \
-                                              --stack-user-domain-name {{ stack_user_domain_name }} | \
-                                              awk -F\= '/stack_user_domain_id/ {print $2}'
+    openstack --os-identity-api-version=3 --os-auth-url={{ auth_identity_uri_v3 }} \
+              domain create {{ stack_domain }} --description "Owns users and projects created by heat"
+  ignore_errors: true
+
+- name: Create heat domain admin user
+  shell: |
+    . /root/openrc
+    openstack --os-identity-api-version=3 --os-auth-url={{ auth_identity_uri_v3 }} \
+              user create --domain {{ stack_user_domain_name }} --password {{ stack_domain_admin_password }} {{ stack_domain_admin }}
+  ignore_errors: true
+
+- name: Retrieve heat domain id
+  shell: |
+    . /root/openrc
+    openstack --os-identity-api-version=3 --os-auth-url={{ auth_identity_uri_v3 }} \
+                    domain show {{ stack_user_domain_name }} | grep -oE -m 1 "[0-9a-f]{32}"
   register: stack_user_domain_id
 
 - name: Set fact for heat domain id
   set_fact:
     stack_user_domain_id: "{{ stack_user_domain_id.stdout }}"
+
+- name: Assign admin role to heat domain admin user
+  shell: |
+    . /root/openrc
+    openstack --os-identity-api-version=3 --os-auth-url={{ auth_identity_uri_v3 }} \
+              role add --user {{ stack_domain_admin }} --domain {{ stack_user_domain_id }} admin

--- a/rpc_deployment/vars/repo_packages/heat.yml
+++ b/rpc_deployment/vars/repo_packages/heat.yml
@@ -38,4 +38,5 @@ service_pip_dependencies:
   - python-keystoneclient
   - python-troveclient
   - python-ceilometerclient
+  - python-openstackclient
   - keystonemiddleware


### PR DESCRIPTION
This change updates the juno ansible code to deploy heat's keystone
domain and domain user using the same method used in icehouse code.
Using heat-keystone-setup-domain is slightly cleaner however this tool
is not available in icehouse's heat.

Closes #195
