### PR TITLE
Be more specific w/ cluster check

### DIFF
--- a/rpc_deployment/roles/rabbit_join_cluster/tasks/main.yml
+++ b/rpc_deployment/roles/rabbit_join_cluster/tasks/main.yml
@@ -18,7 +18,7 @@
 # if node is clustered or not
 - name: Check cluster status
   shell: |
-    rabbitmqctl -q cluster_status | grep {{ rabbit_cluster_name }}
+    rabbitmqctl -q cluster_status | grep '{cluster_name,<<"{{ rabbit_cluster_name }}">>}'
   changed_when: result.rc != 0
   failed_when: false
   register: result


### PR DESCRIPTION
I built a 3 controller setup and noticed that rabbitmq was not
clustering correctly.  Upon closer inspection, the issue was due to the
default cluster name of 'rpc' being found in a cluster_status due to
my hosts have a hostname of rpc-controller-X.  This change is more
specific in what we search for in the cluster_status output so we do
not get false positive backs from the cluster name being reflected in
the container hostnames.

Closes #256
