### PR TITLE
Include a [clients_glance] section in heat.conf

### DIFF
--- a/rpc_deployment/roles/heat_common/templates/heat.conf
+++ b/rpc_deployment/roles/heat_common/templates/heat.conf
@@ -44,6 +44,9 @@ endpoint_type = internalURL
 [clients_cinder]
 endpoint_type = internalURL
 
+[clients_glance]
+endpoint_type = internalURL
+
 [clients_heat]
 endpoint_type = internalURL
 


### PR DESCRIPTION
To ensure that heat uses the internalURL endpoints for glance it is
necessary to explicitly include the [clients_glance] section in the
configuration.

Fixes #274
