### PR TITLE
Default to creating agent token for each entity

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -96,7 +96,9 @@ maas_api_key: "{{ rackspace_cloud_api_key }}"
 maas_auth_token: some_token
 maas_api_url: https://monitoring.api.rackspacecloud.com/v1.0/{{ rackspace_cloud_tenant_id }}
 maas_notification_plan: npTechnicalContactsEmail
-maas_agent_token: some_token
+# By default we will create an agent token for each entity, however if you'd
+# prefer to use the same agent token for all entities then specify it here
+#maas_agent_token: some_token
 maas_target_alias: public0_v4
 maas_scheme: https
 # Override scheme for specific service remote monitor by specifying here: E.g.

--- a/rpc_deployment/roles/raxmon_agent_install/tasks/main.yml
+++ b/rpc_deployment/roles/raxmon_agent_install/tasks/main.yml
@@ -73,6 +73,30 @@
 - name: Assign agent ID to entity
   shell: "raxmon-entities-update --id {{ entity.stdout }} --agent-id {{ entity_name }}"
 
+- name: Agent token {{ entity_name }} count
+  shell: "raxmon-agent-tokens-list | grep ' label={{ entity_name }}, ' | wc -l"
+  register: agent_token_count
+  when: maas_agent_token is not defined
+
+- name: At most one {{ entity_name }} agent token should exist
+  fail:
+    msg: "Agent token count of {{ agent_token_count.stdout }} > 1 for entity with the label {{ entity_name }}"
+  when: maas_agent_token is not defined and agent_token_count.stdout|int > 1
+
+- name: Create agent token
+  shell: "raxmon-agent-tokens-create --label={{ entity_name }}"
+  register: agent_token
+  when: maas_agent_token is not defined and agent_token_count.stdout|int == 0
+
+- name: Get agent token
+  shell: "raxmon-agent-tokens-list | grep '<AgentToken: id=.* label={{ entity_name }}, .*>' | awk '{print $2}' | sed -e 's/id=\\(.*\\),/\\1/g'"
+  register: maas_agent_token_id
+  when: maas_agent_token is not defined
+
+- name: Set agent token fact
+  set_fact: maas_agent_token={{ maas_agent_token_id.stdout }}
+  when: maas_agent_token is not defined
+
 - name: Generate raxmon agent config
   template:
     src: rackspace-monitoring-agent.cfg

--- a/scripts/cloudserver-aio.sh
+++ b/scripts/cloudserver-aio.sh
@@ -209,7 +209,9 @@ maas_api_key: "{{ rackspace_cloud_api_key }}"
 maas_auth_token: some_token
 maas_api_url: https://monitoring.api.rackspacecloud.com/v1.0/{{ rackspace_cloud_tenant_id }}
 maas_notification_plan: npTechnicalContactsEmail
-maas_agent_token: some_token
+# By default we will create an agent token for each entity, however if you'd
+# prefer to use the same agent token for all entities then specify it here
+#maas_agent_token: some_token
 maas_target_alias: public0_v4
 maas_scheme: https
 # Override scheme for specific service remote monitor by specifying here: E.g.


### PR DESCRIPTION
Currently, we require the operator to specify an existing agent token
to use for all entities.  This means the operator needs to make a call
to MaaS to determine the agent token ID before being able to deploy the
environment.  This change creates a new agent token w/ label matching
the entity in question and configures the agent to use that token.  If
the user variable maas_agent_token is defined, then we skip creating an
agent token and use the token specified.

Closes issue #263
