### PR TITLE
Revert 17c5ee87

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -17,9 +17,6 @@
 # UK accounts: https://lon.identity.api.rackspacecloud.com/v2.0
 rackspace_cloud_auth_url: https://identity.api.rackspacecloud.com/v2.0
 rackspace_cloud_tenant_id: SomeTenantID
-# The cloudfiles_tenant_id is the long MossoCloudFS tenantID only required
-# when using glance backed by Rackspace Cloud Files
-rackspace_cloudfiles_tenant_id: SomeTenantID
 rackspace_cloud_username: SomeUserName
 rackspace_cloud_password: SomeUsersPassword
 rackspace_cloud_api_key: SomeAPIKey
@@ -62,7 +59,7 @@ glance_default_store: file
 glance_container_mysql_password:
 glance_service_password:
 glance_swift_store_auth_address: "{{ rackspace_cloud_auth_url }}"
-glance_swift_store_user: "{{ rackspace_cloudfiles_tenant_id }}:{{ rackspace_cloud_username }}"
+glance_swift_store_user: "{{ rackspace_cloud_tenant_id }}:{{ rackspace_cloud_username }}"
 glance_swift_store_key: "{{ rackspace_cloud_password }}"
 glance_swift_store_container: SomeContainerName
 glance_swift_store_region: SomeRegion

--- a/scripts/cloudserver-aio.sh
+++ b/scripts/cloudserver-aio.sh
@@ -156,8 +156,6 @@ required_kernel: 3.13.0-30-generic
 ## Rackspace Cloud Details
 rackspace_cloud_auth_url: https://identity.api.rackspacecloud.com/v2.0
 rackspace_cloud_tenant_id: SomeTenantID
-# The cloudfiles_tenant_id is the long MossoCloudFS tenantID only required
-rackspace_cloudfiles_tenant_id: SomeTenantID
 rackspace_cloud_username: SomeUserName
 rackspace_cloud_password: SomeUsersPassword
 rackspace_cloud_api_key: SomeAPIKey
@@ -185,7 +183,7 @@ glance_default_store: file
 glance_container_mysql_password: secrete
 glance_service_password: secrete
 glance_swift_store_auth_address: "{{ rackspace_cloud_auth_url }}"
-glance_swift_store_user: "{{ rackspace_cloudfiles_tenant_id }}:{{ rackspace_cloud_username }}"
+glance_swift_store_user: "{{ rackspace_cloud_tenant_id }}:{{ rackspace_cloud_username }}"
 glance_swift_store_key: "{{ rackspace_cloud_password }}"
 glance_swift_store_container: SomeContainerName
 glance_swift_store_region: SomeRegion


### PR DESCRIPTION
This change effectively reverts 17c5ee87, but leaves in some additional
comments added by that commit.  We also update the cloudserver-aio.sh
script to reflect this reverted change.

As to why this change is no longer needed, the assumption that needing
a separate cloud files tenant ID to form your glance swift user name
was incorrect.  Using the format of <cloud_tenant_id:cloud_username>
works fine.

Closes issue #281
