### PR TITLE
Disable mariadb query-cache to resolve deadlocks

### DIFF
--- a/rpc_deployment/roles/galera_config/templates/my.cnf
+++ b/rpc_deployment/roles/galera_config/templates/my.cnf
@@ -28,8 +28,8 @@ max_connections = 500
 # CACHES AND LIMITS #
 tmp-table-size = 32M
 max-heap-table-size = 32M
-query-cache-type = 1
-query-cache-size = 50M
+query-cache-type = 0
+query-cache-size = 0M
 max-connections = 500
 thread-cache-size = 50
 open-files-limit = 65535


### PR DESCRIPTION
...plication-cluster-multi-master/galera/getting-started-with-mariadb-galera-cluster/

Disabling query_cache (and setting size to 0M so it doesn't allocate the RAM)
This is a huge reason for seeing deadlocks with Galera, hence the mandatory turning off

Addresses #143 

(cherry picked from commit 5cecca96824b992a93140ae65838b95d5e658232)
