### PR TITLE
Add missing dependency

### DIFF
--- a/rpc_deployment/inventory/group_vars/cinder_all.yml
+++ b/rpc_deployment/inventory/group_vars/cinder_all.yml
@@ -85,6 +85,7 @@ service_pip_dependencies:
   - python-cinderclient
   - python-keystoneclient
   - keystonemiddleware
+  - httplib2
 
 container_directories:
   - /var/log/cinder


### PR DESCRIPTION
In 66d96c3f, we added a dependency on httplib2 but this patch assumes
cinder is using vars/repo_packages, which it isn't on 9.0.x.  This
commit simply adds httplib2 to the correct service_pip_dependencies in
inventory/group_vars/cinder_all.yml.
