### PR TITLE
make container networking timeout slightly less aggressive

### DIFF
--- a/rpc_deployment/roles/container_restart/tasks/main.yml
+++ b/rpc_deployment/roles/container_restart/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Test Container Networking
   wait_for: >
     port=22
-    timeout=10
+    timeout=20
     search_regex=OpenSSH
     host={{ hostvars[item]['container_address'] }}
   with_items: container_groups


### PR DESCRIPTION
fixes #208

(cherry picked from commit 5ec3c6461fab7de9d4f448dd83ad9ad73cee8608)
