### PR TITLE
Fix incorrect usage of file module

### DIFF
--- a/rpc_deployment/roles/horizon_common/tasks/main.yml
+++ b/rpc_deployment/roles/horizon_common/tasks/main.yml
@@ -17,7 +17,7 @@
   file:
     dest: "/etc/horizon"
     recurse: "yes"
-    owner: "{{ system_group }}"
+    owner: "{{ system_user }}"
     group: "{{ system_group }}"
     state: "directory"
 
@@ -34,9 +34,15 @@
     - { src: "local_settings.py", dest: "/etc/horizon/local_settings.py", mode: "0644" }
 
 - name: Copy manage.py to /usr/local/bin/horizon-manage.py
+  command: rsync -ci {{ git_dest }}/manage.py /usr/local/bin/horizon-manage.py
+  register: rsync_result
+  changed_when: rsync_result.stdout != ""
+
+- name: Set permissions on /usr/local/bin/horizon-manage.py
   file:
-    src: "{{ git_dest }}/manage.py"
-    dest: /usr/local/bin/horizon-manage.py
+    path: /usr/local/bin/horizon-manage.py
+    owner: root
+    group: root
     mode: 0755
 
 - name: Remove old links deployed in RPC 9.0.0
@@ -56,7 +62,7 @@
   file:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
-    owner: "{{ system_group }}"
+    owner: "{{ system_user }}"
     group: "{{ system_group }}"
     state: "link"
   with_items:
@@ -66,7 +72,7 @@
   file:
     dest: "{{ item }}"
     recurse: "yes"
-    owner: "{{ system_group }}"
+    owner: "{{ system_user }}"
     group: "{{ system_group }}"
     state: "directory"
   with_items:


### PR DESCRIPTION
The file module does not copy a file from src to dest.  This change
uses rsync to do so, registering a change only when rsync actually
syncs the file.

We also fix some incorrect references to what should be
{{ system_user }}.

Solution found at https://gist.github.com/maxim/7dd6e4d98d8c7d1f4961,
is there any better way of doing this?

Closes issue #302
