### PR TITLE
Allow the default (kvm) for nova_virt_type to be used

### DIFF
--- a/rpc_deployment/roles/nova_compute_devices/tasks/main.yml
+++ b/rpc_deployment/roles/nova_compute_devices/tasks/main.yml
@@ -36,12 +36,12 @@
   shell: >
     lxc-device -n {{ container_name }} add /dev/kvm /dev/kvm
   delegate_to: "{{ physical_host }}"
-  when: nova_virt_type == 'kvm' and is_metal != true
+  when: virt_type == 'kvm' and is_metal != true
 
 - name: Ensure kvm permissions
   shell: >
     udevadm trigger
-  when: nova_virt_type == 'kvm'
+  when: virt_type == 'kvm'
 
 - name: Create log directory
   file:


### PR DESCRIPTION
- Changes the 2 kvm tasks to use "virt_type" instead of "nova_virt_type"
- This var is specified from group_vars file and is defaulted.

Closes-Bug: #242
(cherry picked from commit 6442c00a7a47c4e616b2abd28db9b86efbc6477c)
