### PR TITLE
Time Units For HAProxy Timeouts

### DIFF
--- a/rpc_deployment/vars/config_vars/haproxy_config.yml
+++ b/rpc_deployment/vars/config_vars/haproxy_config.yml
@@ -19,8 +19,8 @@ haproxy_config:
       hap_backup_nodes: "{{ groups['galera'][1:] }}"
       hap_port: 3306
       hap_balance_type: tcp
-      hap_timeout_client: 5000
-      hap_timeout_server: 5000
+      hap_timeout_client: 5000s
+      hap_timeout_server: 5000s
       hap_backend_options:
         - "mysql-check user haproxy"
   - service:


### PR DESCRIPTION
I think the time unit was supposed to be in seconds. If omitted, the default time unit is miliseconds, which I don't think was intended.
