### PR TITLE
set holland backup to minute based on container IP

### DIFF
--- a/rpc_deployment/roles/rpc_support_holland/tasks/holland.yml
+++ b/rpc_deployment/roles/rpc_support_holland/tasks/holland.yml
@@ -71,25 +71,15 @@
     - holland_conf
     - holland_all
 
-- name: Check for holland cron file
-  command: ls /etc/cron.d/holland_backups
-  failed_when: false
-  changed_when: holland_cron.rc != 0
-  register: holland_cron
-  tags:
-    - holland_cron
-    - holland_all
-
 - name: Create holland backup cron job
   cron:
     name: "holland-backup"
-    minute: "{{ 59|random }}"
-    weekday: "{{ 6|random }}"
+    minute: "{{ (ansible_eth0['ipv4']['address']|replace('.', '')|int)%60}}"
+    hour: 23
     state: present
-    job: "holland bk"
+    job: "/usr/local/bin/holland bk"
     user: root
     cron_file: holland_backups
-  when: holland_cron.rc != 0
   tags:
     - holland_cron
     - holland_all


### PR DESCRIPTION
- modulo 60 the container ip after casting it to an int - use this as the minute for the backup time
- set backup hour to 23
- set backup days to all
- add full path of holland binary

Addresses #136 
