### PR TITLE
Templated out iscsi options in the cinder.conf

### DIFF
--- a/rpc_deployment/roles/cinder_common/templates/cinder.conf
+++ b/rpc_deployment/roles/cinder_common/templates/cinder.conf
@@ -2,8 +2,6 @@
 verbose = {{ verbose }}
 debug = {{ debug }}
 
-my_ip={{ container_address }}
-
 rpc_backend = {{ rpc_backend }}
 rabbit_hosts = {{ rabbit_hosts }}
 rabbit_userid = {{ rabbit_userid }}
@@ -31,7 +29,12 @@ glance_api_servers={% for host in groups['glance_api'] %}{{ hostvars[host]['cont
 default_volume_type = {{ cinder_default_volume_type }}
 {% endif %}
 
-iscsi_helper=tgtadm
+iscsi_helper = {{ cinder_iscsi_helper | default('tgtadm') }}
+iscsi_iotype = {{ cinder_iscsi_iotype | default('fileio') }}
+iscsi_ip_address = {{ storage_address | default(container_address) }}
+iscsi_num_targets = {{ cinder_iscsi_num_targets | default('100') }}
+iscsi_port = {{ cinder_iscsi_port | default('3260') }}
+
 volume_name_template = volume-%s
 
 {% if cinder_backends is defined %}


### PR DESCRIPTION
This change adds templates options for iscsi within cinder. This
change was to allow use to set sensible options within the cinder.conf
file that may be required in several different scenarios.

Resolves issue: #328

Cherry-pick from (2f9f159eb6cada460823c0b00bcb48f965d91a93)
