### PR TITLE
Change cirros image_url

### DIFF
--- a/rpc_deployment/roles/tempest_resources/tasks/main.yml
+++ b/rpc_deployment/roles/tempest_resources/tasks/main.yml
@@ -18,7 +18,7 @@
     command: 'image-create'
     openrc_path: /root/openrc
     image_name: cirros
-    image_url: 'https://launchpad.net/cirros/trunk/0.3.2/+download/cirros-0.3.2-source.tar.gz'
+    image_url: 'http://download.cirros-cloud.net/0.3.3/cirros-0.3.3-x86_64-disk.img'
     image_container_format: bare
     image_disk_format: qcow2
     image_is_public: True


### PR DESCRIPTION
Currently we pull down a source tarball for cirros, which obviously
isn't bootable.  This change points to the .img file instead.

Addresses #333 

(cherry picked from commit df75d23def59ef1dc4ae76818e21a9ee498d8655)
