### PR TITLE
Add tempest users to heat_stack_owner role

### DIFF
--- a/rpc_deployment/roles/tempest_resources/tasks/main.yml
+++ b/rpc_deployment/roles/tempest_resources/tasks/main.yml
@@ -50,3 +50,17 @@
   with_items:
     - demo
     - alt_demo
+
+- name: Ensure tempest users have heat_stack_owners role
+  keystone:
+    command: ensure_user_role
+    tenant_name: "{{ item }}"
+    user_name: "{{ item }}"
+    role_name: heat_stack_owner
+    endpoint: "{{ auth_identity_uri }}"
+    login_tenant_name: "{{ auth_admin_tenant }}"
+    login_user: "{{ auth_admin_username }}"
+    login_password: "{{ auth_admin_password }}"
+  with_items:
+    - demo
+    - alt_demo


### PR DESCRIPTION
Any user creating heat stacks needs to be added to this role.  Doing
this resolves some of the failing orchestration tempest tests.

Closes issue #346
