### PR TITLE
Added repo_package variable file to nova-spice-console (master)

### DIFF
--- a/rpc_deployment/playbooks/openstack/nova-spice-console.yml
+++ b/rpc_deployment/playbooks/openstack/nova-spice-console.yml
@@ -16,10 +16,12 @@
 - hosts: nova_spice_console
   user: root
   roles:
+    - container_common
     - nova_common
     - init_script
   vars_files:
     - inventory/group_vars/nova_all.yml
+    - vars/repo_packages/nova_spice_console.yml
     - vars/openstack_service_vars/nova_spice_console.yml
     - vars/openstack_service_vars/nova_spice_console_endpoint.yml
   handlers:


### PR DESCRIPTION
This commit adds the missing repo_pacakges/nova_spice_console.yml file
to the nova-spice-console.yml play.

Closes Issue https://github.com/rcbops/ansible-lxc-rpc/issues/347
