### PR TITLE
Added repo_package variable file to nova-spice-console (proposed/juno)

### DIFF
--- a/rpc_deployment/playbooks/openstack/nova-spice-console.yml
+++ b/rpc_deployment/playbooks/openstack/nova-spice-console.yml
@@ -16,10 +16,12 @@
 - hosts: nova_spice_console
   user: root
   roles:
+    - container_common
     - nova_common
     - init_script
   vars_files:
     - inventory/group_vars/nova_all.yml
+    - vars/repo_packages/nova_spice_console.yml
     - vars/openstack_service_vars/nova_spice_console.yml
     - vars/openstack_service_vars/nova_spice_console_endpoint.yml
   handlers:

--- a/rpc_deployment/vars/repo_packages/python_neutronclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_neutronclient.yml
@@ -19,6 +19,6 @@ repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 git_repo: https://github.com/openstack/python-neutronclient
 git_fallback_repo: https://git.openstack.org/openstack/python-neutronclient
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: 2.3.6
+git_install_branch: 72c1473f111846a026cb5f9eb97d68b435eba194
 
 pip_wheel_name: python-neutronclient


### PR DESCRIPTION
This commit adds the missing repo_pacakges/nova_spice_console.yml file
to the nova-spice-console.yml play.

Cherry-pick from 154ad40ff4b6cca9568b889b7e3e0615001fc460

Closes Issue https://github.com/rcbops/ansible-lxc-rpc/issues/347
