### PR TITLE
Updated neutron client sha (master)

### DIFF
--- a/rpc_deployment/vars/repo_packages/python_neutronclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_neutronclient.yml
@@ -19,6 +19,6 @@ repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 git_repo: https://github.com/openstack/python-neutronclient
 git_fallback_repo: https://git.openstack.org/openstack/python-neutronclient
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: 2.3.6
+git_install_branch: 72c1473f111846a026cb5f9eb97d68b435eba194
 
 pip_wheel_name: python-neutronclient


### PR DESCRIPTION
This PR changes the sha of the neutron client. This change is needed so that
we are not attempting to install a neutron client for juno which is known to
be broken.

Closes Issues https://github.com/rcbops/ansible-lxc-rpc/issues/350
