### PR TITLE
Default swift-proxy group for haproxy purposes

### DIFF
--- a/rpc_deployment/vars/config_vars/haproxy_config.yml
+++ b/rpc_deployment/vars/config_vars/haproxy_config.yml
@@ -180,6 +180,6 @@ haproxy_config:
         - "ssl-hello-chk"
   - service:
       hap_service_name: swift_proxy
-      hap_backend_nodes: "{{ groups['swift_proxy'] }}"
+      hap_backend_nodes: "{{ groups['swift_proxy']|default('no_swift-proxy_servers') }}"
       hap_port: 8888
       hap_balance_type: http


### PR DESCRIPTION
This avoids a situation where we can't setup haproxy as swift isn't being used.
Default the swift-proxy group to a string so the key error is avoided.

Fixes: #375
