### PR TITLE
Changed DB stamp for Juno

### DIFF
--- a/rpc_deployment/inventory/group_vars/neutron_all.yml
+++ b/rpc_deployment/inventory/group_vars/neutron_all.yml
@@ -41,7 +41,7 @@ service_plugins:
 dhcp_driver: neutron.agent.linux.dhcp.Dnsmasq
 neutron_config: /etc/neutron/neutron.conf
 neutron_plugin: /etc/neutron/plugins/ml2/ml2_conf.ini
-neutron_revision: head
+neutron_revision: juno
 
 ## Neutron downtime
 neutron_agent_down_time: 120


### PR DESCRIPTION
Juno has a DB stamp in it's history that it should be set to, presently
the stamp is set to head. This change ensures that we are using the
proper DB revision.

Closes Issues https://github.com/rcbops/ansible-lxc-rpc/issues/380
