### PR TITLE
Backport - Juno - Removes DHCP replication function from neutron_ha_tool

### DIFF
--- a/rpc_deployment/roles/neutron_l3_ha/tasks/main.yml
+++ b/rpc_deployment/roles/neutron_l3_ha/tasks/main.yml
@@ -39,4 +39,8 @@
     cron_file: "{{ item.name }}"
   with_items:
     - { name: "l3_agent_migrate", command: "--l3-agent-migrate" }
-    - { name: "replicate_dhcp", command: "--replicate-dhcp" }
+
+- name: Remove replicate_dhcp if found.
+  file:
+    path: "/etc/cron.d/replicate_dhcp"
+    state: "absent"


### PR DESCRIPTION
The DHCP replication causes cluster issues with neutron in Juno.
DHCP replication is now handled in Neutron proper.  Additionally,
the DHCP replication function in the tool is redundant and should
be removed.

Cherry Pick from 03e91b17203ee0b3f6739ed29ab98afcfb87ba88
