### PR TITLE
Monitoring changes

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -115,7 +115,6 @@ maas_monitoring_zones:
   - mzord
   - mzlon
   - mzhkg
-maas_repo_version: v9.0.0
 # Specify the maas_fqdn_extension, defaults to empty string.
 # This will be appended to the inventory_name of a host for MaaS purposes.
 # The inventory name + maas_fqdn_extension must match the entity name in MaaS

--- a/rpc_deployment/playbooks/monitoring/raxmon-all.yml
+++ b/rpc_deployment/playbooks/monitoring/raxmon-all.yml
@@ -13,10 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Drop .raxrc file
-  template:
-    src: raxrc.j2
-    dest: /root/.raxrc
-    mode: 0600
-    owner: root
-    group: root
+- include: raxmon_cli.yml
+- include: raxmon_agent.yml

--- a/rpc_deployment/playbooks/monitoring/raxmon_agent.yml
+++ b/rpc_deployment/playbooks/monitoring/raxmon_agent.yml
@@ -16,11 +16,13 @@
 - hosts: hosts
   user: root
   roles:
+    - container_common
     - galera_client_cnf
-    - raxmon_cli
     - raxmon_agent_install
   vars:
     entity_name: "{{ inventory_hostname }}{{ maas_fqdn_extension|default('') }}"
+  vars_files:
+    - vars/repo_packages/raxmon_agent.yml
 
 - hosts: keystone[0]
   user: root

--- a/rpc_deployment/playbooks/monitoring/raxmon_cli.yml
+++ b/rpc_deployment/playbooks/monitoring/raxmon_cli.yml
@@ -13,8 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-raxmon_agent_key:
-  - "https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc"
-
-raxmon_agent_repos:
-  - { repo: "deb http://stable.packages.cloudmonitoring.rackspace.com/ubuntu-14.04-x86_64 cloudmonitoring main", state: "present" }
+- hosts: hosts
+  user: root
+  roles:
+    - common
+    - raxmon_cli
+  vars_files:
+    - vars/repo_packages/raxmon_cli.yml

--- a/rpc_deployment/roles/raxmon_agent_install/tasks/main.yml
+++ b/rpc_deployment/roles/raxmon_agent_install/tasks/main.yml
@@ -13,32 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Add apt key for the raxmon agent
-  apt_key:
-    url: "{{ item }}"
-    state: present
-  with_items: raxmon_agent_key
-
-- name: Configure raxmon agent repo
-  apt_repository: >
-    repo="{{ item.repo }}"
-    state="{{ item.state }}"
-  with_items: raxmon_agent_repos
-
-- name: Install raxmon agent packages
-  apt:
-    pkg: "{{ item }}"
-    state: latest
-    update_cache: yes
-    cache_valid_time: 600
-  with_items:
-    - rackspace-monitoring-agent
-
 - name: Clone plugins repo
   git:
-    repo: https://github.com/rcbops/rpc-maas.git
+    repo: "{{ git_repo }}"
     dest: /usr/lib/rackspace-monitoring-agent/plugins/
-    version: "{{ maas_repo_version }}"
+    version: "{{ git_install_branch }}"
 
 - name: Chmod plugins
   file: path={{ item }} mode=0755
@@ -55,7 +34,7 @@
 
 - name: Install python dependencies
   pip:
-    requirements: /usr/lib/rackspace-monitoring-agent/plugins/requirements.txt
+    requirements: "{{ pip_requirements_file }}"
 
 - name: Entity {{ entity_name }} count
   shell: "raxmon-entities-list | grep ' label={{ entity_name }} provider=Rackspace Monitoring ...>$' | wc -l"

--- a/rpc_deployment/vars/repo_packages/raxmon_agent.yml
+++ b/rpc_deployment/vars/repo_packages/raxmon_agent.yml
@@ -13,12 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-repo_package_name: raxmon
-
-git_repo: https://github.com/rcbops/rpc-maas
-git_install_branch: "master"
-git_dest: /usr/lib/rackspace-monitoring-agent/plugins/
-
 apt_container_keys:
   - { url: "https://monitoring.api.rackspacecloud.com/pki/agent/linux.asc", state: "present" }
 
@@ -28,7 +22,7 @@ apt_container_repos:
 container_packages:
   - rackspace-monitoring-agent
 
-service_pip_dependencies:
-  - rackspace-monitoring-cli
-
 pip_requirements_file: "/usr/lib/rackspace-monitoring-agent/plugins/requirements.txt"
+
+git_repo: https://github.com/rcbops/rpc-maas.git
+git_install_branch: master

--- a/rpc_deployment/vars/repo_packages/raxmon_cli.yml
+++ b/rpc_deployment/vars/repo_packages/raxmon_cli.yml
@@ -13,10 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Drop .raxrc file
-  template:
-    src: raxrc.j2
-    dest: /root/.raxrc
-    mode: 0600
-    owner: root
-    group: root
+service_pip_dependencies:
+  - rackspace-monitoring-cli

--- a/scripts/cloudserver-aio.sh
+++ b/scripts/cloudserver-aio.sh
@@ -228,7 +228,6 @@ maas_monitoring_zones:
   - mzord
   - mzlon
   - mzhkg
-maas_repo_version: v9.0.0
 ## Neutron Options
 neutron_container_mysql_password: secrete
 neutron_service_password: secrete


### PR DESCRIPTION
This change brings the monitoring playbooks/roles in line w/ how
everything else gets deployed by leveraging pre-existing roles for
repo configuration, software installation, etc.  We also split out the
agent and cli more so that the roles can be applied independently of
one-another.

Closes issue #255
