### PR TITLE
Ensure swift-proxy containers aren't created when not using swift.

### DIFF
--- a/etc/rpc_deploy/rpc_environment.yml
+++ b/etc/rpc_deploy/rpc_environment.yml
@@ -272,7 +272,7 @@ container_skel:
     - utility
   swift_proxy_container:
     belongs_to:
-    - infra_containers
+    - swift-proxy_containers
     contains:
     - swift_proxy
   swift_acc_container:

--- a/etc/rpc_deploy/rpc_user_config.yml
+++ b/etc/rpc_deploy/rpc_user_config.yml
@@ -15,7 +15,7 @@
 
 # This is the md5 of the environment file
 # this will ensure consistency when deploying.
-environment_version: 701a1a44b7d77473f3b930f21f78cddf
+environment_version: 95332806ba0a53a6aa2fa83ead06be97
 
 # User defined CIDR used for containers
 # Global cidr/s used for everything.


### PR DESCRIPTION
- Adjust the environment so that swift_proxy isn't part of infra
- Fix md5sum for environment file in rpc_user_config

HAProxy will work without swift-proxy containers as the group exists
in the inventory but is empty. The VIP will be created but has no
backends.

Fixes: #392
Fixes: #393
