### PR TITLE
remove memcache from f5 config generator

### DIFF
--- a/scripts/f5-config.py
+++ b/scripts/f5-config.py
@@ -173,15 +173,6 @@ POOL_PARTS = {
         'group': 'horizon',
         'hosts': []
     },
-    'memcached': {
-        'port': 11211,
-        'backend_port': 11211,
-        'mon_type': 'tcp',
-        'group': 'memcached',
-        'priority': True,
-        'limit_source': True,
-        'hosts': []
-    },
     'elasticsearch': {
         'port': 9200,
         'backend_port': 9200,


### PR DESCRIPTION
Since we now supply a list of memcache servers for each service, they will not need to go via the load balancer any more

Addresses #373
