### PR TITLE
Fix rpc_environment hash in rpc_user_config

### DIFF
--- a/etc/rpc_deploy/rpc_user_config.yml
+++ b/etc/rpc_deploy/rpc_user_config.yml
@@ -15,7 +15,7 @@
 
 # This is the md5 of the environment file
 # this will ensure consistency when deploying.
-environment_version: 95332806ba0a53a6aa2fa83ead06be97
+environment_version: dc4cd5fe9c07eee223e8bbb1c5bbaad5
 
 # User defined CIDR used for containers
 # Global cidr/s used for everything.


### PR DESCRIPTION
Following the fix for swift_proxy the environment hash was incorrect.
This fixes that hash value.

Part of Bug: #392
