### PR TITLE
Use root pass for galera init script

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -37,7 +37,6 @@ container_openstack_password:
 
 ## Galera Options
 mysql_root_password:
-mysql_debian_sys_maint_password:
 
 
 ## Keystone Options

--- a/rpc_deployment/inventory/group_vars/galera.yml
+++ b/rpc_deployment/inventory/group_vars/galera.yml
@@ -18,8 +18,6 @@ service_name: mysql
 container_lvm_fstype: ext4
 container_lvm_fssize: 5GB
 
-debian_sys_maint_password: "{{ mysql_debian_sys_maint_password }}"
-
 # Size of the galera cache
 galera_gcache_size: 1G
 

--- a/rpc_deployment/roles/galera_config/templates/debian.cnf
+++ b/rpc_deployment/roles/galera_config/templates/debian.cnf
@@ -1,11 +1,11 @@
 [client]
 host     = localhost
-user     = debian-sys-maint
-password = {{ debian_sys_maint_password }}
+user     = root
+password = {{ mysql_password }}
 socket   = /var/run/mysqld/mysqld.sock
 [mysql_upgrade]
 host     = localhost
-user     = debian-sys-maint
-password = {{ debian_sys_maint_password }}
+user     = root
+password = {{ mysql_password }}
 socket   = /var/run/mysqld/mysqld.sock
 basedir  = /usr

--- a/rpc_deployment/roles/galera_setup/tasks/main.yml
+++ b/rpc_deployment/roles/galera_setup/tasks/main.yml
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Debian-sys-maint account is used to start/stop mysql. The password is auto
-# generated but must be the same otherwise once data is synced, two nodes
-# will not be able to start/stop mysql.
 - name: Create mysql users
   mysql_user:
     name: "{{ item.name }}"
@@ -35,12 +32,6 @@
       password: ""
       priv: "*.*:ALL"
       state: absent
-
-    - name: "debian-sys-maint"
-      host: 'localhost'
-      password: "{{ debian_sys_maint_password }}"
-      priv: "*.*:ALL"
-      state: present
 
     - name: haproxy
       host: '%'


### PR DESCRIPTION
The galera init script uses the debian-sys-maint account to shutdown
mysql. However this password cannot be preseeded, and is randomly
generated on install. Also it is set in the database so must be updated
when replication has been achieved.

This patch implements an alternative: Use the mysql root password for
init script operations (shutdown). This password is preseedable and will
work at any state of replication.

This is no less secure than previous state as we already write root galera
credentials to /root/.my.cnf (0600) and /etc/mysql/debian.cnf is also 0600.

Related: #411
