### PR TITLE
Use local socket for mysql client connection

### DIFF
--- a/rpc_deployment/roles/galera_client_cnf/templates/client_my.cnf
+++ b/rpc_deployment/roles/galera_client_cnf/templates/client_my.cnf
@@ -1,4 +1,4 @@
 [client]
-host={{ mysql_address }}
+socket=/var/run/mysqld/mysqld.sock
 user=root
 password={{ mysql_password }}


### PR DESCRIPTION
This affects mysql client as well as mysqladmin, which is used in status
checks in the init script. It is important that the init script can
succeed regardless of LB state. (Prior to this commit, LB IP was used as
the host to connect to).

Related: #413
