### PR TITLE
Specialise galera client config

### DIFF
--- a/rpc_deployment/inventory/group_vars/galera.yml
+++ b/rpc_deployment/inventory/group_vars/galera.yml
@@ -15,6 +15,11 @@
 
 service_name: mysql
 
+# Defaults to mysql_address (VIP) when unset.
+# Should only be set for the galera group so that they always connect to
+# their own instance.
+mysql_client_host: 127.0.0.1
+
 container_lvm_fstype: ext4
 container_lvm_fssize: 5GB
 

--- a/rpc_deployment/roles/galera_client_cnf/templates/client_my.cnf
+++ b/rpc_deployment/roles/galera_client_cnf/templates/client_my.cnf
@@ -1,4 +1,4 @@
 [client]
-socket=/var/run/mysqld/mysqld.sock
+host={{ mysql_client_host|default(mysql_address) }}
 user=root
 password={{ mysql_password }}


### PR DESCRIPTION
For reliable operation, the mysql client configuration must point to the
local instance, within galera containers. However this prevents the
mysql client from working on other constainers (eg utility).

This patch defaults the mysql connection to the VIP, then overrides that
to 127.0.0.1 for galera containers.

Related: #413
