### PR TITLE
Set swift to use init scripts instead of swift-init

### DIFF
--- a/rpc_deployment/handlers/swift_services.yml
+++ b/rpc_deployment/handlers/swift_services.yml
@@ -13,10 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: swift proxy server configuration
-  template: >
-    src="proxy-server.conf.j2"
-    dest="/etc/swift/proxy-server.conf"
-    owner={{ service_admin_username }}
-    mode=0644
-  notify: Restart swift service
+- name: Restart swift service
+  service: name={{ item }} state=restarted pattern={{ item }}
+  register: service_restart
+  with_items: program_names
+  notify: Fail if swift restart fails
+
+- name: Fail if swift restart fails
+  fail:
+    msg: 'Service {{ item.cmd }} Failed'
+  when: "'msg' in item and 'FAIL' in item.msg|upper"
+  with_items: service_restart.results
+  notify: Ensure swift service running
+
+- name: Ensure swift service running
+  service: name={{ item }} state=started pattern={{ item }}
+  with_items: service_names

--- a/rpc_deployment/playbooks/openstack/swift-account.yml
+++ b/rpc_deployment/playbooks/openstack/swift-account.yml
@@ -13,10 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: swift proxy server configuration
-  template: >
-    src="proxy-server.conf.j2"
-    dest="/etc/swift/proxy-server.conf"
-    owner={{ service_admin_username }}
-    mode=0644
-  notify: Restart swift service
+- hosts: swift_hosts
+  user: root
+  roles:
+    - swift_init_scripts
+    - swift_account
+  vars_files:
+    - vars/openstack_service_vars/swift_account.yml
+  handlers:
+    - include: handlers/swift_services.yml

--- a/rpc_deployment/playbooks/openstack/swift-container.yml
+++ b/rpc_deployment/playbooks/openstack/swift-container.yml
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: Replace this with init scripts
-- name: Restart proxy server
-  shell: swift-init proxy-server restart || swift-init proxy-server restart
+- hosts: swift_hosts
+  user: root
+  roles:
+    - swift_init_scripts
+    - swift_container
+  vars_files:
+    - vars/openstack_service_vars/swift_container.yml
+  handlers:
+    - include: handlers/swift_services.yml

--- a/rpc_deployment/playbooks/openstack/swift-object.yml
+++ b/rpc_deployment/playbooks/openstack/swift-object.yml
@@ -13,15 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: Replace these with init scripts
-- name: Restart container server
-  shell: swift-init container-server restart || swift-init container-server restart
-
-- name: Restart container auditor
-  shell: swift-init container-auditor restart || swift-init container-auditor restart
-
-- name: Restart container replicator
-  shell: swift-init container-replicator restart || swift-init container-replicator restart 
-
-- name: Restart container updater
-  shell: swift-init container-updater restart || swift-init container-updater restart
+- hosts: swift_hosts
+  user: root
+  roles:
+    - swift_init_scripts
+    - swift_object
+  vars_files:
+    - vars/openstack_service_vars/swift_object.yml
+  handlers:
+    - include: handlers/swift_services.yml

--- a/rpc_deployment/playbooks/openstack/swift-proxy.yml
+++ b/rpc_deployment/playbooks/openstack/swift-proxy.yml
@@ -17,9 +17,13 @@
   user: root
   roles:
     - swift_common
+    - swift_init_scripts
     - swift_proxy
   vars_files:
     - inventory/group_vars/swift_all.yml
+    - vars/openstack_service_vars/swift_proxy.yml
+  handlers:
+    - include: handlers/swift_services.yml
 
 - hosts: swift_proxy[0]
   user: root
@@ -27,4 +31,3 @@
     - keystone_add_service
   vars_files:
     - vars/openstack_service_vars/swift_proxy_endpoint.yml
-

--- a/rpc_deployment/playbooks/openstack/swift-storage.yml
+++ b/rpc_deployment/playbooks/openstack/swift-storage.yml
@@ -18,8 +18,9 @@
   roles:
     - swift_common
     - swift_storage_setup
-    - swift_container
-    - swift_object
-    - swift_account
   vars_files:
     - inventory/group_vars/swift_all.yml
+
+- include: swift-object.yml
+- include: swift-account.yml
+- include: swift-container.yml

--- a/rpc_deployment/roles/swift_account/tasks/main.yml
+++ b/rpc_deployment/roles/swift_account/tasks/main.yml
@@ -19,32 +19,4 @@
     dest="/etc/swift/account-server.conf"
     owner={{ system_user }}
     mode=0644
-  notify:
-    - Restart account server
-    - Restart account auditor
-    - Restart account replicator
-    - Restart account reaper
-
-- name: "Set account server to start at boot"
-  cron: >
-    name="Restart account-server on boot"
-    special_time=reboot
-    job="swift-init account-server start"
-
-- name: "Set account auditor to start at boot"
-  cron: >
-    name="Restart account-auditor on boot"
-    special_time=reboot
-    job="swift-init account-auditor start"
-
-- name: "Set account replicator to start at boot"
-  cron: >
-    name="Restart account-replicator on boot"
-    special_time=reboot
-    job="swift-init account-replicator start"
-
-- name: "Set account reaper to start at boot"
-  cron: >
-    name="Restart account-reaper on boot"
-    special_time=reboot
-    job="swift-init account-reaper start"
+  notify: Restart swift service

--- a/rpc_deployment/roles/swift_container/tasks/main.yml
+++ b/rpc_deployment/roles/swift_container/tasks/main.yml
@@ -19,32 +19,4 @@
     dest="/etc/swift/container-server.conf"
     owner={{ system_user }}
     mode=0644
-  notify:
-    - Restart container server
-    - Restart container auditor
-    - Restart container replicator
-    - Restart container updater
-
-- name: "Set container server to start at boot"
-  cron: >
-    name="Restart container-server on boot"
-    special_time=reboot
-    job="swift-init container-server start"
-
-- name: "Set container auditor to start at boot"
-  cron: >
-    name="Restart container-auditor at boot"
-    special_time=reboot
-    job="swift-init container-auditor start"
-
-- name: "Set container replicator to start at boot"
-  cron: >
-    name="Restart container-replicator at boot"
-    special_time=reboot
-    job="swift-init container-replicator start"
-
-- name: "Set container updater to start at boot"
-  cron: >
-    name="Restart container-updater at boot"
-    special_time=reboot
-    job="swift-init container-updater start"
+  notify: Restart swift service

--- a/rpc_deployment/roles/swift_init_scripts/handlers/main.yml
+++ b/rpc_deployment/roles/swift_init_scripts/handlers/main.yml
@@ -13,10 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: swift proxy server configuration
-  template: >
-    src="proxy-server.conf.j2"
-    dest="/etc/swift/proxy-server.conf"
-    owner={{ service_admin_username }}
-    mode=0644
-  notify: Restart swift service
+- name: Restart service
+  service: name={{ item }} state=restarted pattern={{ item }} enabled=yes
+  when: item is defined

--- a/rpc_deployment/roles/swift_init_scripts/tasks/main.yml
+++ b/rpc_deployment/roles/swift_init_scripts/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Place the init script
+  template: >
+    src=init-config
+    dest=/etc/init/{{ item }}.conf
+    mode=0644
+    owner=root
+    group=root
+  with_items: program_names
+  notify: Restart service
+  
+- name: Ensure init scripts are loaded
+  shell: >
+    initctl list | grep -w "{{ item }}"
+  with_items: program_names
+  register: init_loaded
+
+- name: Reload init scripts
+  shell: >
+    initctl reload-configuration
+  when: item.rc != 0
+  with_items: init_loaded.results
+
+- name: Load service
+  service: name={{ item }} enabled=yes
+  when: item is defined
+  with_items: program_names
+
+- name: Ensure service started
+  service: name={{ item }} state=started pattern={{ item }} enabled=yes
+  when: item is defined
+  with_items: program_names

--- a/rpc_deployment/roles/swift_init_scripts/templates/init-config
+++ b/rpc_deployment/roles/swift_init_scripts/templates/init-config
@@ -1,0 +1,39 @@
+# {{ ansible_managed }}
+# vim:set ft=upstart ts=2 et:
+
+description "{{ item }}"
+author "Kevin Carter <kevin.carter@rackspace.com>"
+
+start on runlevel [2345]
+stop on runlelvel [016]
+
+respawn
+
+# Set the RUNBIN environment variable
+env RUNBIN="/usr/local/bin/{{ item }}"
+
+# Change directory to service users home
+chdir "/var/lib/{{ service_name }}"
+
+# Pre start actions
+pre-start script
+  mkdir -p "/var/run/{{ item }}"
+  chown {{ system_user }}:{{ system_group }} "/var/run/{{ item }}"
+
+  mkdir -p "/var/lock/{{ item }}"
+  chown {{ system_user }}:{{ system_group }} "/var/lock/{{ item }}"
+end script
+
+# Post stop actions
+post-stop script
+  rm "/var/run/{{ item }}/{{ item }}.pid"
+end script
+
+# Run the start up job
+exec start-stop-daemon --start \
+                       --chuid {{ system_user }} \
+                       --make-pidfile \
+                       --pidfile /var/run/{{ item }}/{{ item }}.pid \
+                       --exec "{{ program_override|default('$RUNBIN') }}" \
+                       /etc/{{ service_name }}/{{ service_conf }} \
+                       -- {{ program_config_options|default('') }}

--- a/rpc_deployment/roles/swift_object/tasks/main.yml
+++ b/rpc_deployment/roles/swift_object/tasks/main.yml
@@ -19,32 +19,4 @@
     dest="/etc/swift/object-server.conf"
     owner={{ system_user }}
     mode=0644
-  notify:
-    - Restart object server
-    - Restart object auditor
-    - Restart object replicator
-    - Restart object updater
-
-- name: "Set object server to start at boot"
-  cron: >
-    name="Restart object-server on boot"
-    special_time=reboot
-    job="swift-init object-server start"
-
-- name: "Set object auditor to start at boot"
-  cron: >
-    name="Restart object-auditor on boot"
-    special_time=reboot
-    job="swift-init object-auditor start"
-
-- name: "Set object replicator to start at boot"
-  cron: >
-    name="Restart object-replicator on boot"
-    special_time=reboot
-    job="swift-init object-replicator start"
-
-- name: "Set object updater to start at boot"
-  cron: >
-    name="Restart object-updater on boot"
-    special_time=reboot
-    job="swift-init object-updater start"
+  notify: Restart swift service

--- a/rpc_deployment/vars/openstack_service_vars/swift_account.yml
+++ b/rpc_deployment/vars/openstack_service_vars/swift_account.yml
@@ -13,15 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: Replace these with init scripts
-- name: Restart object server
-  shell: swift-init object-server restart || swift-init object-server restart
+# The variables file used by the playbooks in the Heat-API group.
+# These don't have to be explicitly imported by vars_files: they are autopopulated.
 
-- name: Restart object auditor
-  shell: swift-init object-auditor restart || swift-init object-auditor restart
+program_names:
+  - swift-account-server
+  - swift-account-auditor
+  - swift-account-replicator
+  - swift-account-reaper
 
-- name: Restart object replicator
-  shell: swift-init object-replicator restart || swift-init object-replicator restart
-
-- name: Restart object updater
-  shell: swift-init object-updater restart || swift-init object-updater restart
+service_conf: account-server.conf

--- a/rpc_deployment/vars/openstack_service_vars/swift_container.yml
+++ b/rpc_deployment/vars/openstack_service_vars/swift_container.yml
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: swift proxy server configuration
-  template: >
-    src="proxy-server.conf.j2"
-    dest="/etc/swift/proxy-server.conf"
-    owner={{ service_admin_username }}
-    mode=0644
-  notify: Restart swift service
+# The variables file used by the playbooks in the Heat-API group.
+# These don't have to be explicitly imported by vars_files: they are autopopulated.
+
+program_names:
+  - swift-container-server
+  - swift-container-auditor
+  - swift-container-replicator
+  - swift-container-reaper
+
+service_conf: container-server.conf

--- a/rpc_deployment/vars/openstack_service_vars/swift_object.yml
+++ b/rpc_deployment/vars/openstack_service_vars/swift_object.yml
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: swift proxy server configuration
-  template: >
-    src="proxy-server.conf.j2"
-    dest="/etc/swift/proxy-server.conf"
-    owner={{ service_admin_username }}
-    mode=0644
-  notify: Restart swift service
+# The variables file used by the playbooks in the Heat-API group.
+# These don't have to be explicitly imported by vars_files: they are autopopulated.
+
+program_names:
+  - swift-object-server
+  - swift-object-auditor
+  - swift-object-replicator
+  - swift-object-reaper
+
+service_conf: object-server.conf

--- a/rpc_deployment/vars/openstack_service_vars/swift_proxy.yml
+++ b/rpc_deployment/vars/openstack_service_vars/swift_proxy.yml
@@ -13,15 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: Replace these with init scripts
-- name: Restart account server
-  shell: swift-init account-server restart || swift-init account-server restart
+# The variables file used by the playbooks in the Heat-API group.
+# These don't have to be explicitly imported by vars_files: they are autopopulated.
 
-- name: Restart account auditor
-  shell: swift-init account-auditor restart || swift-init account-auditor restart
+program_names:
+  - swift-proxy-server
 
-- name: Restart account replicator
-  shell: swift-init account-replicator restart || swift-init account-replicator restart
-
-- name: Restart account reaper
-  shell: swift-init account-reaper restart || swift-init account-reaper restart
+service_conf: proxy-server.conf


### PR DESCRIPTION
Swift services need to be set up as system services.
This ensures all the swift services are setup with init files, and ensures
that all swift services start on boot appropriatley.
Due to each swift service having 4 services new handlers and init script
roles had to be created.
- Add handler for swift service restarts
- Add init script role for swift
- Add program_names vars files for each swift service
- Split services into separate plays
- Remove old handler files per service.

Fixes-Bug: #394
