### PR TITLE
Change maas_notification_plan to npManaged

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -92,7 +92,7 @@ maas_username: "{{ rackspace_cloud_username }}"
 maas_api_key: "{{ rackspace_cloud_api_key }}"
 maas_auth_token: some_token
 maas_api_url: https://monitoring.api.rackspacecloud.com/v1.0/{{ rackspace_cloud_tenant_id }}
-maas_notification_plan: npTechnicalContactsEmail
+maas_notification_plan: npManaged
 # By default we will create an agent token for each entity, however if you'd
 # prefer to use the same agent token for all entities then specify it here
 #maas_agent_token: some_token

--- a/scripts/cloudserver-aio.sh
+++ b/scripts/cloudserver-aio.sh
@@ -208,7 +208,7 @@ maas_username: "{{ rackspace_cloud_username }}"
 maas_api_key: "{{ rackspace_cloud_api_key }}"
 maas_auth_token: some_token
 maas_api_url: https://monitoring.api.rackspacecloud.com/v1.0/{{ rackspace_cloud_tenant_id }}
-maas_notification_plan: npTechnicalContactsEmail
+maas_notification_plan: npManaged
 # By default we will create an agent token for each entity, however if you'd
 # prefer to use the same agent token for all entities then specify it here
 #maas_agent_token: some_token


### PR DESCRIPTION
When set to npTechnicalContactEmail for customers without a cloud
account, alarm creation will fail with an "Unable to create Alarm due to issues with account contact information. Please contact support"
error. Changing to npManaged allows alert creation to complete so alarm
tickets can be created.

Issue rcbops/ansible-lxc-rpc#402

(cherry picked from commit 47f992328cdf8ef739afd7e698b5df1741bfdedb)
