### PR TITLE
Backport - Icehouse - Changed release version to match the branch

### DIFF
--- a/rpc_deployment/inventory/group_vars/all.yml
+++ b/rpc_deployment/inventory/group_vars/all.yml
@@ -41,7 +41,7 @@ external_vip_address: "{{ external_lb_vip_address }}"
 
 ## URL for the frozen rpc repo
 rpc_repo_url: "http://rpc-slushee.rackspace.com"
-rpc_release: "9.0.0"
+rpc_release: "stable/icehouse"
 
 ## GPG Keys
 gpg_keys:


### PR DESCRIPTION
This changes the release version in the to the name of the branch instead of the version number which has no hold on the state of the branch.

This resolves issue https://github.com/rcbops/ansible-lxc-rpc/issues/421
