### PR TITLE
Add variable for container restart timeout

### DIFF
--- a/rpc_deployment/inventory/group_vars/all.yml
+++ b/rpc_deployment/inventory/group_vars/all.yml
@@ -189,3 +189,6 @@ logstash_port: 5544
 
 # Directory where serverspec is installed to on utility container
 serverspec_install_dir: /opt/serverspec
+
+# How long to wait for a container after a (re)start
+container_start_timeout: 180

--- a/rpc_deployment/roles/container_common/tasks/add_interfaces.yml
+++ b/rpc_deployment/roles/container_common/tasks/add_interfaces.yml
@@ -34,7 +34,7 @@
 - name: Wait for container networking
   wait_for: >
     port=22
-    timeout=60
+    timeout={{ container_start_timeout }}
     search_regex=OpenSSH
     host={{ container_address }}
   when: restarted_container|changed and is_metal != true

--- a/rpc_deployment/roles/container_extra_setup/tasks/container_setup.yml
+++ b/rpc_deployment/roles/container_extra_setup/tasks/container_setup.yml
@@ -44,7 +44,7 @@
   wait_for:
     port: "22"
     search_regex: "OpenSSH"
-    timeout: "60"
+    timeout: "{{ container_start_timeout }}"
     host: "{{ container_address }}"
   delegate_to: localhost
   when: inner_extra_changed|changed or local_extra_changed|changed or config_extra_changed|changed

--- a/rpc_deployment/roles/container_restart/tasks/main.yml
+++ b/rpc_deployment/roles/container_restart/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Check Networking After Restart
   wait_for: >
     port=22
-    timeout=60
+    timeout={{ container_start_timeout }}
     search_regex=OpenSSH
     host={{ hostvars[item]['container_address'] }}
   with_items: container_groups

--- a/rpc_deployment/roles/neutron_add_network_interfaces/tasks/main.yml
+++ b/rpc_deployment/roles/neutron_add_network_interfaces/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Wait for container networking
   wait_for: >
     port=22
-    timeout=60
+    timeout={{ container_start_timeout }}
     search_regex=OpenSSH
     host={{ container_address }}
   when: restarted_container|changed and is_metal != true


### PR DESCRIPTION
Sometimes containers faill to start in time, this change allows us to
control the container start timeout with a single variable.

Related: #427
