### PR TITLE
Backport - Icehouse - Ensure that rsyslog state files are unique

### DIFF
--- a/rpc_deployment/roles/rsyslog_config/templates/genlog.py
+++ b/rpc_deployment/roles/rsyslog_config/templates/genlog.py
@@ -31,11 +31,14 @@ for log in matches:
         container = log.split('/')[3]
         service = log.split('/')[4].split('.')[0]
         if 'horizon' in container:
-                service = container + '_' + service
+            service = container + '_' + service
+
+        if 'logstash' in container:
+            continue
 
         print "$InputFileName {}".format(log)
-        print "$InputFileTag {}:".format(container)
-        print "$InputFileStateFile state-{}".format(service)
+        print "$InputFileTag {}.{}:".format(container, service)
+        print "$InputFileStateFile state-{}-{}".format(container, service)
         print "$InputFileFacility local7"
         print "$InputRunFileMonitor\n"
 


### PR DESCRIPTION
Since there are certain containers that contain multiple logfiles
we need to ensure that there is a state file for each log file and
not just for each container.  This causes rsyslog to spool endlessly.

Partially fixes #205
