### PR TITLE
Backport - stable/icehouse - updated pip installation process

### DIFF
--- a/rpc_deployment/roles/common/tasks/install_pip_deps.yml
+++ b/rpc_deployment/roles/common/tasks/install_pip_deps.yml
@@ -16,7 +16,7 @@
 - name: Install pip dependencies
   pip:
     name: "{{ item }}"
-    extra_args: "--allow-all-external"
+    extra_args: "{{ pip_install_options|default('') }}"
   with_items: service_pip_dependencies
   when: service_pip_dependencies is defined
   register: pip_install

--- a/rpc_deployment/roles/common/templates/pip/base/global.conf.j2
+++ b/rpc_deployment/roles/common/templates/pip/base/global.conf.j2
@@ -2,3 +2,7 @@
 no-index = true
 pre = true
 timeout = 120
+
+[install]
+upgrade = true
+allow_all_external = true

--- a/rpc_deployment/roles/openstack_common/tasks/pip_install.yml
+++ b/rpc_deployment/roles/openstack_common/tasks/pip_install.yml
@@ -14,12 +14,24 @@
 # limitations under the License.
 
 - name: Install service source
-  pip: >
-    name="/opt/{{ service_name }}_{{ git_install_branch | replace('/', '_') }}"
-    extra_args="{{ pip_install_options|default('') }} --allow-all-external"
+  pip:
+    name: "/opt/{{ service_name }}_{{ git_install_branch | replace('/', '_') }}"
+    extra_args: "{{ pip_install_options|default('') }}"
   register: pip_install
   until: pip_install|success
   retries: 5
   async: 1800
   delay: 5
   poll: 5
+
+- name: Install pip repo plugins
+  pip:
+    name: "{{ git_dest }}/{{ item.path }}/{{ item.package }}"
+    extra_args: "{{ pip_install_options|default('') }}"
+  when: git_dest is defined and git_repo_plugins is defined
+  with_items: git_repo_plugins
+  register: pip_install
+  until: pip_install|success
+  retries: 5
+  delay: 10
+

--- a/scripts/rpc-wheel-builder.sh
+++ b/scripts/rpc-wheel-builder.sh
@@ -13,22 +13,128 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Notes:
+# To use this script you MUST move it to some path that will be called.
+# I recommend that the script be stored and executed from 
+# "/opt/rpc-wheel-builder.sh". This script is a wrapper script that relies
+#  on the "rpc-wheel-builder.py" and is execute from
+# "/opt/rpc-wheel-builder.py".
+
+# Overrides:
+# This script has several things that can be overriden via environment 
+# variables.
+#     Git repository that the rcbops ansible lxc source code will be cloned from. 
+#     This repo should be a repo that is available via HTTP.
+#     GIT_REPO=""
+
+#     The URI for the github api. This is ONLY used when the $RELEASES variable
+#     is an empty string. Which causes the script to go discover the available
+#     releases.
+#     GITHUB_API_ENDPOINT=""
+
+#     Local directory to store the source code while interacting with it.
+#     WORK_DIR=""
+
+#     Local directory to store the built wheels.
+#     OUTPUT_WHEEL_PATH=""
+
+#     Local directory to store known git repos.
+#     OUTPUT_GIT_PATH=""
+
+#     Space seperated list of all releases to build for. If unset the releases
+#     will be discovered.
+#     RELEASES=""
+
+#     Space seperated list of all releases to exclude from building. This is
+#     ONLY used when the $RELEASES variable is an empty string.
+#     EXCLUDE_RELEASES=""
+
 set -e -o -v
 
-WORK_DIR="/opt/ansible-lxc-rpc"
-GIT_REPO="https://github.com/rcbops/ansible-lxc-rpc"
-REPO_PACKAGES_PATH="/opt/ansible-lxc-rpc/rpc_deployment/vars/repo_packages/"
-OUTPUT_WHEEL_PATH="/var/www/repo/python_packages"
-RELEASE=$1
+# Ensure there is a base path loaded
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-rm -rf /tmp/rpc_wheels*
-rm -rf /tmp/pip*
-rm -rf "${WORK_DIR}"
+# Defined variables
+GIT_REPO="${GIT_REPO:-https://github.com/rcbops/ansible-lxc-rpc}"
+GITHUB_API_ENDPOINT="${GITHUB_API_ENDPOINT:-https://api.github.com/repos/rcbops/ansible-lxc-rpc}"
 
-git clone "${GIT_REPO}" "${WORK_DIR}"
-pushd "${WORK_DIR}"
-  git checkout "${RELEASE}"
-popd
+WORK_DIR="${WORK_DIR:-/opt/ansible-lxc-rpc}"
+REPO_PACKAGES_PATH="${WORK_DIR}/rpc_deployment/vars/repo_packages/"
 
-${WORK_DIR}/scripts/rpc-wheel-builder.py -i "${REPO_PACKAGES_PATH}" \
-                                         -o "${OUTPUT_WHEEL_PATH}"/"${RELEASE}"
+OUTPUT_WHEEL_PATH="${OUTPUT_WHEEL_PATH:-/var/www/repo/python_packages}"
+OUTPUT_GIT_PATH="${OUTPUT_GIT_PATH:-/var/www/repo/rpcgit}"
+
+# Default is an empty string which causes the script to go discover the available
+# branches from the github API.
+RELEASES=${RELEASES:-""}
+
+EXCLUDE_RELEASES="${EXCLUDE_RELEASES:-v9.0.0 gh-pages revert}"
+
+if [[ ! "${RELEASES}" ]];then
+# From the GITHUB API pull a list of all branches/tags
+RELEASES=$(
+$(which python) <<EOF
+import requests
+
+# Create an array of excluded items
+EXCLUDE = "${EXCLUDE_RELEASES}".split()
+
+def return_releases(url):
+    """Return a list of releases found in the github api.
+
+    :param url: ``str``
+    """
+    _releases = requests.get(url)
+    loaded_releases = _releases.json()
+    releases = list()
+    for i in loaded_releases:
+        for k, v in i.iteritems():
+            if k == 'name':
+                # if the name is not excluded append it
+                if not any([v.startswith(i) for i in EXCLUDE]):
+                    releases.append(v)
+    else:
+        # Return a unique list.
+        return list(set(releases))
+
+all_releases = list()
+all_releases.extend(return_releases(url="${GITHUB_API_ENDPOINT}/tags"))
+all_releases.extend(return_releases(url="${GITHUB_API_ENDPOINT}/branches"))
+print(' '.join(all_releases))
+EOF
+)
+fi
+
+
+function cleanup() {
+    # Ensure workspaces are cleaned up
+    rm -rf /tmp/rpc_wheels*
+    rm -rf /tmp/pip*
+    rm -rf "${WORK_DIR}"    
+}
+
+
+# Iterate through the list of releases and build everything that's needed
+for release in ${RELEASES}; do
+
+    # Perform cleanup
+    cleanup
+
+    # Git clone repo
+    git clone "${GIT_REPO}" "${WORK_DIR}"
+
+    # checkout release
+    pushd "${WORK_DIR}"
+      git checkout "${release}"
+    popd
+
+    # Build wheels
+    /opt/rpc-wheel-builder.py -i "${REPO_PACKAGES_PATH}" \
+                              -o "${OUTPUT_WHEEL_PATH}"/pools \
+                              --link-dir "${OUTPUT_WHEEL_PATH}"/"${release}" \
+                              --git-repos "${OUTPUT_GIT_PATH}" \
+                              --release "${release}"
+done
+
+# Perform cleanup
+cleanup


### PR DESCRIPTION
This PR updates the current Wheel building scripts such that they create a pool directory with all of the wheels build and links back to the built wheels in a given release directory. These changes ensure that we are not storing duplicate version of files in duplicate directories while also ensuring consistency when building wheels for a new release.

Other improvements ensure that whenever pip is invoked the latest packages are installed from within the "frozen" repository of python wheels. This simplifies the arguments by added the required flags and section to the roles/common/templates/pip/base/global.conf.j2 file.

These changes are presently powering our forzen python wheels and should be added into master. This work was done in preparation to move our stuff to the rax mirror.

Cherry pick from: cb84e8f
