### PR TITLE
backport - stable/icehouse - Increase ssh timeout in ansible.cfg

### DIFF
--- a/rpc_deployment/ansible.cfg
+++ b/rpc_deployment/ansible.cfg
@@ -5,8 +5,11 @@ host_key_checking = False
 
 # Setting forks should be based on your system. The ansible defaults to 5, 
 # the ansible-rpc-lxc assumes that you have a system that can support 
-# openstack, thus it has been conservitivly been set to 25
-forks = 25
+# openstack, thus it has been conservitivly been set to 15
+forks = 15
+
+# SSH timeout
+timeout = 120
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
Backport from https://github.com/rcbops/ansible-lxc-rpc/pull/358
Resolves issue https://github.com/rcbops/ansible-lxc-rpc/issues/358

Cherry-pick from 955846b25021d199f9f781eb1aedc5a35ae75aad
