### PR TITLE
Increase delay and retries for lxc cache download

### DIFF
--- a/rpc_deployment/roles/lxc_common/tasks/lxc_container_cache.yml
+++ b/rpc_deployment/roles/lxc_common/tasks/lxc_container_cache.yml
@@ -21,7 +21,8 @@
   register: cache_download
   async: 600
   poll: 15
-  retries: 3
+  retries: 10
+  delay: 120
   until: cache_download|success
 
 - name: Move lxc cached image into place


### PR DESCRIPTION
This may increase run time, but thats better than having to re-run, esp
in the gate.

Related: #449
