### PR TITLE
Add backup and retry for keyservers

### DIFF
--- a/rpc_deployment/inventory/group_vars/all.yml
+++ b/rpc_deployment/inventory/group_vars/all.yml
@@ -45,7 +45,11 @@ rpc_release: master
 
 ## GPG Keys
 gpg_keys:
-  - { key_name: 'mariadb', keyserver: 'hkp://keyserver.ubuntu.com:80', hash_id: '0xcbcb082a1bb943db' }
+  - { key_name: 'mariadb', hash_id: '0xcbcb082a1bb943db' }
+
+gpg_keyservers:
+  - 'hkp://keyserver.ubuntu.com:80'
+  - 'hkp://pgp.mit.edu:80'
 
 
 ## Repositories

--- a/rpc_deployment/roles/common/tasks/repos.yml
+++ b/rpc_deployment/roles/common/tasks/repos.yml
@@ -15,11 +15,17 @@
 
 - name: add apt-keys
   apt_key:
-    id: "{{ item.hash_id }}"
-    keyserver: "{{ item.keyserver }}"
+    id: "{{ item[0].hash_id }}"
+    keyserver: "{{ item[1] }}"
     state: "present"
-  with_items: gpg_keys
+  with_nested:
+    - gpg_keys
+    - gpg_keyservers
   when: "ansible_distribution_version in ['12.04', '13.04', '13.10', '14.04']"
+  ignore_errors: true
+  register: add_keys
+  until: add_keys|success
+  retries: 3
 
 - name: Add Common repos
   apt_repository:


### PR DESCRIPTION
Try to get gpg keys from multiple keyservers, retry on failure.

Related: #446
