### PR TITLE
[backport] [proposed/juno] This commit allows for more galera/mysql tuning

### DIFF
--- a/rpc_deployment/roles/galera_config/templates/cluster.cnf
+++ b/rpc_deployment/roles/galera_config/templates/cluster.cnf
@@ -22,7 +22,7 @@ wsrep_node_name={{ ansible_hostname }}
 # SST method
 wsrep_sst_method=xtrabackup
 wsrep_sst_auth=root:{{ mysql_password }}
-wsrep_slave_threads=16
+wsrep_slave_threads={{ galera_wsrep_slave_threads | default(ansible_processor_vcpus) }}
 
 # Cluster name
 wsrep_cluster_name="rpc_galera_cluster"

--- a/rpc_deployment/roles/galera_config/templates/my.cnf
+++ b/rpc_deployment/roles/galera_config/templates/my.cnf
@@ -1,3 +1,12 @@
+{%- set all_calculated_max_connections = [] %}
+
+{%- for galera_node in groups['galera_all'] %}
+    {%- if all_calculated_max_connections.append(hostvars[galera_node]['ansible_processor_vcpus'] * 100) %}
+    {%- endif %}
+{%- endfor %}
+
+{%- set calculated_max_connections = all_calculated_max_connections|sort %}
+
 [client]
 port = 3306
 socket = /var/run/mysqld/mysqld.sock
@@ -23,14 +32,19 @@ character-set-server = utf8
 # SAFETY #
 max-allowed-packet = 16M
 max-connect-errors = 1000000
-max_connections = 500
+
+# NOTE: The number of max connections is defined by ( host_vcpus * 100 ). This value
+# is the lowest integer based on the ansible facts gathered from every galera node.
+# Computing the connections value using the lowest denominator maintains cluster integrity
+# by not attempting to over commit to a less capable machine.
+# These are the computed max_connections based on cluster data {{ calculated_max_connections }}
+max_connections = {{ mysql_max_connections | default(calculated_max_connections[0]) }}
 
 # CACHES AND LIMITS #
 tmp-table-size = 32M
 max-heap-table-size = 32M
 query-cache-type = 0
 query-cache-size = 0M
-max-connections = 500
 thread-cache-size = 50
 open-files-limit = 65535
 table-definition-cache = 4096


### PR DESCRIPTION
The change allows the user to change the "mysql_max_connections" as variable
If unset, the default will be (100 \* ansible_processor_vcpus). This is based
on the facts gathered by ansible. All galera nodes will be used in computing
the value of the max_connections and the lowest denominator will be used.

This change also modifies the count of wsrep sync thread based on the
the number of CPU cores available on a given host as defined by ansible
facts. This function can also be overridden using the "galera_wsrep_slave_threads"
variable.

(cherry picked from commit 4af49b1c4f716f4e0da4b181230a6e530e42ec96)

Resolves #410
Related Issue: #429
