### PR TITLE
Updated cinder.conf to allow for AZ setup

### DIFF
--- a/etc/rpc_deploy/rpc_user_config.yml
+++ b/etc/rpc_deploy/rpc_user_config.yml
@@ -133,6 +133,12 @@ storage_hosts:
     # "container_vars" can be set outside of all other options as 
     # host specific optional variables.
     container_vars:
+      # If you would like to define a cinder availablility zone this can
+      # be done with the namespaced variable.
+      cinder_storage_availability_zone: cinderAZ_1
+      # When creating more than ONE availablity zone you should define a
+      # sane default for the system to use when schedulng volume creation.
+      cinder_default_availability_zone: cinderAZ_1
       # In this example we are defining what cinder volumes are 
       # on a given host.
       cinder_backends:
@@ -147,6 +153,17 @@ storage_hosts:
           volume_group: cinder-volumes
           volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
           volume_backend_name: LVM_iSCSI
+  cinder2:
+    ip: 172.29.236.105
+    container_vars:
+      cinder_storage_availability_zone: cinderAZ_2
+      cinder_default_availability_zone: cinderAZ_1
+      cinder_backends:
+        limit_container_types: cinder_volume
+        lvm_ssd:
+          volume_group: cinder-volumes
+          volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
+          volume_backend_name: LVM_iSCSI_SSD
 
 # User defined Logging Hosts, this should be a required group
 log_hosts:

--- a/etc/rpc_deploy/rpc_user_config.yml.example
+++ b/etc/rpc_deploy/rpc_user_config.yml.example
@@ -149,36 +149,32 @@ compute_hosts:
 # User defined Storage Hosts, this should be a required group
 storage_hosts:
   cinder1:
-    ip: 10.240.0.104
-    # "container_vars" can be set outside of all other options as 
-    # host specific optional variables.
+    ip: 172.29.236.104
     container_vars:
-      # In this example we are defining what cinder volumes are 
-      # on a given host.
+      cinder_storage_availability_zone: cinderAZ_1
+      cinder_default_availability_zone: cinderAZ_1
       cinder_backends:
-        # if the "limit_container_types" argument is set, within 
-        # the top level key of the provided option the inventory
-        # process will perform a string match on the container name with
-        # the value found within the "limit_container_types" argument.
-        # If any part of the string found within the container 
-        # name the options are appended as host_vars inside of inventory.
         limit_container_types: cinder_volume
         lvm:
           volume_group: cinder-volumes
           volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
           volume_backend_name: LVM_iSCSI
   cinder2:
-    ip: 10.240.0.105
+    ip: 172.29.236.105
     container_vars:
+      cinder_storage_availability_zone: cinderAZ_2
+      cinder_default_availability_zone: cinderAZ_1
       cinder_backends:
         limit_container_types: cinder_volume
         lvm_ssd:
           volume_group: cinder-volumes
           volume_driver: cinder.volume.drivers.lvm.LVMISCSIDriver
-          volume_backend_name: LVM_SSD_iSCSI
+          volume_backend_name: LVM_iSCSI_SSD
   cinder3:
     ip: 10.240.0.106
     container_vars:
+      cinder_storage_availability_zone: cinderAZ_3
+      cinder_default_availability_zone: cinderAZ_1
       cinder_backends:
         limit_container_type: cinder_volume
         netapp:

--- a/rpc_deployment/roles/cinder_common/templates/cinder.conf
+++ b/rpc_deployment/roles/cinder_common/templates/cinder.conf
@@ -25,6 +25,12 @@ glance_port={{ glance_port|default('9292') }}
 glance_num_retries=0
 glance_api_servers={% for host in groups['glance_api'] %}{{ hostvars[host]['container_address'] }}:{{ glance_port|default('9292') }}{% if not loop.last %},{% endif %}{% endfor %}
 
+storage_availability_zone = {{ cinder_storage_availability_zone|default('nova') }}
+
+{% if cinder_default_availability_zone is defined %}
+cinder_default_availability_zone = {{ cinder_default_availability_zone }}
+{% endif %}
+
 {% if cinder_default_volume_type is defined %}
 default_volume_type = {{ cinder_default_volume_type }}
 {% endif %}


### PR DESCRIPTION
This commit provides variables to all for the creation of cinder
availability zones. With this setup you can now create a cinder
volume container in a targeted availability zone and define a
default az. The new variables are:
- cinder_storage_availability_zone
- cinder_default_availability_zone

Each variable is a string value. The variable **cinder_default_availability_zone**
is optional and will default to the the scoped **cinder_storage_availability_zone**
variable when undefined per the documentation in Openstack `cinder.conf`.

These changes were documented in the example configuration files as well.

Resolves Issue https://github.com/rcbops/ansible-lxc-rpc/issues/458
