### PR TITLE
Backport to stable/icehouse - Added repo_package variable file to nova-spice-console

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 9.0.2 - 2014-11-05
+## 9.0.2 - 2014-11-06
 
 - Increase delay and retries for lxc cache download [#449]
 - Updated cinder.conf to allow for AZ setup [#458]
@@ -15,6 +15,7 @@
 - Changed release version to match the branch [#421]
 - Changed maas_notification_plan to npManaged [#402]
 - Added galera alarms [#403]
+- Added repo_package variable file to nova-spice-console [#347]
 - Resolved issue with neutron HA failover cron clobbering other crons [#383,#378]
 
 ## 9.0.1 - 2014-10-17

--- a/rpc_deployment/playbooks/openstack/nova-spice-console.yml
+++ b/rpc_deployment/playbooks/openstack/nova-spice-console.yml
@@ -26,6 +26,7 @@
     - init_script
   vars_files:
     - inventory/group_vars/nova_all.yml
+    - vars/repo_packages/nova_spice_console.yml
     - vars/openstack_service_vars/nova_spice_console.yml
     - vars/openstack_service_vars/nova_spice_console_endpoint.yml
   handlers:


### PR DESCRIPTION
This commit adds the missing repo_pacakges/nova_spice_console.yml file
to the nova-spice-console.yml play.

(cherry picked from commit 154ad40ff4b6cca9568b889b7e3e0615001fc460)

Conflicts:
    rpc_deployment/playbooks/openstack/nova-spice-console.yml

Related-bug: #347
