### PR TITLE
Create an empty 'authorized_keys' file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Increase delay and retries for lxc cache download [#449]
 - Updated cinder.conf to allow for AZ setup [#458]
+- Create empty 'authorized_keys' file [#478]
 - Use {{ ansible_fqdn }} for service checks [#452]
 - Allow for more galera/mysql tuning [#410,#429]
 - Increase ssh timeout in ansible.cfg [#358]

--- a/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
+++ b/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
@@ -38,6 +38,9 @@
 - name: Create the nova SSH key if it doesnt exist
   shell: su - nova -c 'ssh-keygen -f /var/lib/nova/.ssh/id_rsa -t rsa -q -N ""'
 
+- name: Create empty 'authorized_keys' file
+  file: path="/var/lib/nova/.ssh/authorized_keys" state="touch"
+
 - name: Change permissions on the generated keys
   file:
     path: "{{ item.path }}"
@@ -45,6 +48,7 @@
     owner: "nova"
     mode: "{{ item.mode }}"
   with_items:
+    - { path: "/var/lib/nova/.ssh/authorized_keys", mode: "0700" }
     - { path: "/var/lib/nova/.ssh/id_rsa", mode: "0600" }
     - { path: "/var/lib/nova/.ssh/id_rsa.pub", mode: "0644" }
 


### PR DESCRIPTION
(cherry picked from commit 13825a9a63b134048d26daafc86ef7e750043dda)

Addresses backport for #478 
