### PR TITLE
Make cloudserver-aio.sh pull stable/icehouse in the stable/icehouse version

### DIFF
--- a/scripts/cloudserver-aio.sh
+++ b/scripts/cloudserver-aio.sh
@@ -15,7 +15,7 @@
 set -e -u -v -x
 
 REPO_URL=${REPO_URL:-"https://github.com/rcbops/ansible-lxc-rpc.git"}
-REPO_BRANCH=${REPO_BRANCH:-"master"}
+REPO_BRANCH=${REPO_BRANCH:-"stable/icehouse"}
 FROZEN_REPO_URL=${FROZEN_REPO:-"http://rpc-slushee.rackspace.com"}
 MAX_RETRIES=${MAX_RETRIES:-5}
 


### PR DESCRIPTION
This is a fix for #493.
