### PR TITLE
Backport to proposed/juno - Change value of SECRET_KEY

### DIFF
--- a/rpc_deployment/inventory/group_vars/horizon.yml
+++ b/rpc_deployment/inventory/group_vars/horizon.yml
@@ -50,7 +50,7 @@ install_lib_dir: /usr/local/lib/python2.7/dist-packages
 
 container_directories:
   - "/etc/horizon"
-  - "{{ install_lib_dir }}"
+  - "/var/lib/horizon"
 
 horizon_fqdn: "{{ external_vip_address }}"
 horizon_server_name: "{{ container_name }}"

--- a/rpc_deployment/roles/horizon_common/templates/local_settings.py
+++ b/rpc_deployment/roles/horizon_common/templates/local_settings.py
@@ -95,7 +95,7 @@ LOCAL_PATH = os.path.dirname(os.path.abspath(__file__))
 # requests routed to the same dashboard instance or you set the same SECRET_KEY
 # for all of them.
 from horizon.utils import secret_key
-SECRET_KEY = secret_key.generate_or_read_from_file(os.path.join(LOCAL_PATH, '.secret_key_store'))
+SECRET_KEY = secret_key.generate_or_read_from_file('/var/lib/horizon/.secret_key_store')
 
 # We recommend you use memcached for development; otherwise after every reload
 # of the django development server, you will have to login again. To use


### PR DESCRIPTION
Currently SECRET_KEY points to
{ install_lib_dir }}/openstack_dashboard/local/.secret_key_store
however this directory is not writable by www-data:www-data and
attempting to load horizon results in a LockFailed exception being
raised.  Rather than making
{ install_lib_dir }}/openstack_dashboard/local/ writable by
www-data:www-data, we create /var/lib/horizon and point SECRET_KEY to
/var/lib/horizon/.secret_key_stone.

(cherry picked from commit 75b4bbf4fc0be60f22972422f2234836618a12cb)

Conflicts:
    rpc_deployment/inventory/group_vars/horizon.yml

Related-bug: #362 
