### PR TITLE
[JUNO] Updates python-glanceclient release

### DIFF
--- a/rpc_deployment/vars/repo_packages/python_glanceclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_glanceclient.yml
@@ -19,6 +19,6 @@ repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 git_repo: https://github.com/openstack/python-glanceclient
 git_fallback_repo: https://git.openstack.org/openstack/python-glanceclient
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: 0.14.1
+git_install_branch: b126351d9d61fac777b72707620583dcb516e8d5
 
 pip_wheel_name: python-glanceclient


### PR DESCRIPTION
This update changes the glance client sha to a version that will
allow for the internal URL to be used which was broken in version
0.14.1/2.

Related issue: https://github.com/rcbops/ansible-lxc-rpc/issues/473
