### PR TITLE
Allow default drives to be specified for swift

### DIFF
--- a/etc/rpc_deploy/conf.d/swift.yml
+++ b/etc/rpc_deploy/conf.d/swift.yml
@@ -10,6 +10,9 @@
 # You can set one policy to be "default: yes" this will be the default storage policy for non-legacy containers that are created.
 # The index value must be unique.
 # Storage policies can be set to "deprecated: yes" which will mean they are not used
+# You can specify default drives in the global_overrides section, these drives will be used
+# if no other drives are specified per device. These work in the same way as the per node
+# drives, so the same settings can be used.
 
 # global_overrides:
 #   swift:
@@ -30,6 +33,9 @@
 #          index: 1
 #          repl_number: 2
 #          deprecated: yes
+#     drives:
+#       - name: sdb
+#       - name: sdc
 
 # User defined Swift Proxy hosts - not required when not using swift
 # Will deploy a swift-proxy container on these hosts.

--- a/rpc_deployment/roles/swift_ring_builder/templates/swift_rings.py
+++ b/rpc_deployment/roles/swift_ring_builder/templates/swift_rings.py
@@ -22,6 +22,7 @@ import pickle
 import sys
 import threading
 import json
+import copy
 
 USAGE = "usage: %prog -s <rpc_inventory.json>"
 
@@ -225,13 +226,20 @@ def main(setup):
         return 1
 
     _hosts = {}
+    # Get the swift specific global vars
+    global_vars  = _inventory['all']['vars']
+    check_section(global_vars, 'swift')
+    swift_vars = global_vars['swift']
     if _inventory.get("swift_hosts"):
         for host in _inventory['swift_hosts']['hosts']:
             host_config = _inventory['_meta']['hostvars'][host]
             host_vars = host_config['swift_vars']
             host_ip = host_vars.get('ip', host_config['container_address'])
             if not host_vars.get('drives'):
-                continue
+                if not swift_vars.get('drives'):
+                    continue
+                else:
+                    host_vars['drives'] = copy.deepcopy(swift_vars.get('drives'))
             host_drives = host_vars.get('drives')
             for host_drive in host_drives:
                 host_drive['ip'] = host_drive.get('ip', host_ip)

--- a/rpc_deployment/roles/swift_storage_setup/tasks/main.yml
+++ b/rpc_deployment/roles/swift_storage_setup/tasks/main.yml
@@ -20,3 +20,13 @@
     group: "{{ system_group }}"
     state: "directory"
   with_items: swift_vars.drives
+  when: swift_vars.drives is defined
+
+- name: "Set ownership on default mounted drives"
+  file:
+    dest: "{{ swift_vars.mount_point }}/{{ item.name }}"
+    owner: "{{ system_user }}"
+    group: "{{ system_group }}"
+    state: "directory"
+  with_items: swift.drives
+  when: swift_vars.drives is not defined


### PR DESCRIPTION
- Drives can now be specified in the global variables
- Drives specified per device will take precedence

Fixes: #511
