### PR TITLE
This commit adds a check to the dynamic inventory script when parsing extra values

### DIFF
--- a/rpc_deployment/inventory/dynamic_inventory.py
+++ b/rpc_deployment/inventory/dynamic_inventory.py
@@ -252,7 +252,10 @@ def _append_to_host_groups(inventory, container_type, assignment, host_type,
                 if isinstance(container_vars, dict):
                     for _keys, _vars in container_vars.items():
                         # Copy the options dictionary for manipulation
-                        options = _vars.copy()
+                        if isinstance(_vars, dict):
+                            options = _vars.copy()
+                        else:
+                            options = _vars
 
                         limit = None
                         # If a limit is set use the limit string as a filter


### PR DESCRIPTION
This commit adds a check to the dynamic inventory script when parsing extra values.
Presently the script expects a dict, however if the user passes a key with a string value 
the inventory parser breaks. This PR simply adds a check to the scrip to ensure that this
does not happen.

(cherry picked from commit 767aa6229dfb6e907bd2473e1f8efe235ebed44a)

Addresses issue: #458 
