### PR TITLE
Minor usability tweak to rpc_user_config - group lb entries

### DIFF
--- a/etc/rpc_deploy/rpc_user_config.yml
+++ b/etc/rpc_deploy/rpc_user_config.yml
@@ -43,6 +43,8 @@ global_overrides:
   internal_lb_vip_address: 172.29.236.1
   # External DMZ VIP address
   external_lb_vip_address: 192.168.1.1
+  # Name of load balancer
+  lb_name: lb_name_in_core
   # Bridged interface to use with tunnel type networks
   tunnel_bridge: "br-vxlan"
   # Bridged interface to build containers with
@@ -109,8 +111,6 @@ global_overrides:
         type: "vlan"
         range: "1:1"
         net_name: "vlan"
-  # Name of load balancer
-  lb_name: lb_name_in_core
 
 # User defined Infrastructure Hosts, this should be a required group
 infra_hosts:

--- a/etc/rpc_deploy/rpc_user_config.yml.example
+++ b/etc/rpc_deploy/rpc_user_config.yml.example
@@ -43,6 +43,8 @@ global_overrides:
   internal_lb_vip_address: 172.29.236.10
   # External DMZ VIP address
   external_lb_vip_address: 192.168.1.1
+  # Name of load balancer
+  lb_name: lb_name_in_core
   # Bridged interface to use with tunnel type networks
   tunnel_bridge: "br-vxlan"
   # Bridged interface to build containers with
@@ -109,8 +111,6 @@ global_overrides:
         type: "vlan"
         range: "1:1"
         net_name: "vlan"
-  # Name of load balancer
-  lb_name: lb_name_in_core
   # Other options you may want
   debug: True
   ### Cinder default volume type option


### PR DESCRIPTION
This patch is to simply group the load balancer yaml config items. In the current state it's very easy to miss the lb_name configuration item, which may result in an undesirable or failed deployment.
