### PR TITLE
Changes frozen repo to point to mirror.rackspace.com

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ requests==2.4.1
 cloudlib==0.0.8
 pip==1.5.6
 wheel==0.24.0
-http://rpc-slushee.rackspace.com/downloads/ansible-1.6.10.tar.gz
+http://mirror.rackspace.com/rackspaceprivatecloud/downloads/ansible-1.6.10.tar.gz

--- a/rpc_deployment/inventory/group_vars/all.yml
+++ b/rpc_deployment/inventory/group_vars/all.yml
@@ -40,7 +40,7 @@ external_vip_address: "{{ external_lb_vip_address }}"
 
 
 ## URL for the frozen rpc repo
-rpc_repo_url: "http://rpc-slushee.rackspace.com"
+rpc_repo_url: "http://mirror.rackspace.com/rackspaceprivatecloud"
 rpc_release: master
 
 ## GPG Keys
@@ -55,7 +55,7 @@ apt_common_repos:
 apt_lxc_common_repos:
   - { repo: "ppa:ubuntu-lxc/stable", state: "present" }
 
-get_pip_url: "http://rpc-slushee.rackspace.com/downloads/get-pip.py"
+get_pip_url: "http://mirror.rackspace.com/rackspaceprivatecloud/downloads/get-pip.py"
 
 
 ## Users that will not be created via container_common

--- a/rpc_deployment/vars/repo_packages/all_common.yml
+++ b/rpc_deployment/vars/repo_packages/all_common.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 ## URL for the frozen rpc repo
-rpc_repo_url: "http://rpc-slushee.rackspace.com"
+rpc_repo_url: "http://mirror.rackspace.com/rackspaceprivatecloud"
 
 ## GPG Keys
 gpg_keys:
@@ -31,9 +31,9 @@ apt_common_repos:
 # Hyphens and periods replaced with underlines. This will ensure that when ansible 
 # runs into the ``apt_common_repos`` option is set correctly.
 # apt_common_repos:
-#   - { repo: "deb [arch=amd64] {{ rpc_repo_url }} rpc-LA main", state: "present", name: "rpc_slushee_rackspace_com" }
-#   - { repo: "deb [arch=amd64] {{ rpc_repo_url }} LA main", state: "present", name: "rpc_slushee_rackspace_com" }
-#   - { repo: "deb [arch=amd64] {{ rpc_repo_url }} universe-LA universe", state: "present", name: "rpc_slushee_rackspace_com" }
+#   - { repo: "deb [arch=amd64] {{ rpc_repo_url }} rpc-LA main", state: "present", name: "mirror_rackspace_com" }
+#   - { repo: "deb [arch=amd64] {{ rpc_repo_url }} LA main", state: "present", name: "mirror_rackspace_com" }
+#   - { repo: "deb [arch=amd64] {{ rpc_repo_url }} universe-LA universe", state: "present", name: "mirror_rackspace_com" }
 
 ## Python pip
 get_pip_url: "{{ rpc_repo_url }}/downloads/get-pip.py"

--- a/scripts/cloudserver-aio.sh
+++ b/scripts/cloudserver-aio.sh
@@ -16,7 +16,7 @@ set -e -u -v -x
 
 REPO_URL=${REPO_URL:-"https://github.com/rcbops/ansible-lxc-rpc.git"}
 REPO_BRANCH=${REPO_BRANCH:-"master"}
-FROZEN_REPO_URL=${FROZEN_REPO_URL:-"http://rpc-slushee.rackspace.com"}
+FROZEN_REPO_URL=${FROZEN_REPO_URL:-"http://mirror.rackspace.com/rackspaceprivatecloud"}
 MAX_RETRIES=${MAX_RETRIES:-5}
 
 apt-get update

--- a/scripts/rpc-aio-heat-template.yml
+++ b/scripts/rpc-aio-heat-template.yml
@@ -34,7 +34,7 @@ parameters:
     description: The aio script installation URL
   frozen_repo_url:
     type: string
-    default: http://rpc-slushee.rackspace.com
+    default: http://mirror.rackspace.com/rackspaceprivatecloud
     description: URL to the frozen
   repo_url:
     type: string

--- a/scripts/rpc-aio-rax-heat-template.yml
+++ b/scripts/rpc-aio-rax-heat-template.yml
@@ -34,7 +34,7 @@ parameters:
     description: The aio script installation URL
   frozen_repo_url:
     type: string
-    default: http://rpc-slushee.rackspace.com
+    default: http://mirror.rackspace.com/rackspaceprivatecloud
     description: URL to the frozen
   repo_url:
     type: string


### PR DESCRIPTION
The rpc-slushee.rackspace.com has numerous issues, so
we have created mirror.rackspace.com/rackspaceprivatecloud
to address those issues.  All instances of rpc-slushee
have been replaced.

Fixes #527
