### PR TITLE
updated release for Issue531 -> stable/icehouse

### DIFF
--- a/rpc_deployment/vars/repo_packages/ansible_rpc_lxc.yml
+++ b/rpc_deployment/vars/repo_packages/ansible_rpc_lxc.yml
@@ -17,6 +17,6 @@ repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 
 ## Git Source
 git_repo: "https://github.com/rcbops/ansible-lxc-rpc"
-git_install_branch: 22dd0baba7b1e0f496794ee59c968738df1a257d
+git_install_branch: stable/icehouse
 
 pip_wheel_name: ansible-lxc-rpc


### PR DESCRIPTION
Removed the VERY old sha that was being set for the stable/icehouse that pointed at anything but a stable or icehouse related release.

Fixes issue: https://github.com/rcbops/ansible-lxc-rpc/issues/531
