### PR TITLE
Create alarms for discovered devices

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -120,6 +120,8 @@ maas_repo_version: 10.0.0rc1
 # This will be appended to the inventory_name of a host for MaaS purposes.
 # The inventory name + maas_fqdn_extension must match the entity name in MaaS
 # maas_fqdn_extension: .example.com
+# Set the following to skip creating alarms for this device
+#maas_excluded_devices: ['xvde']
 
 ## Neutron Options
 neutron_container_mysql_password:

--- a/rpc_deployment/playbooks/monitoring/maas_local.yml
+++ b/rpc_deployment/playbooks/monitoring/maas_local.yml
@@ -338,14 +338,14 @@
 
 - hosts: hosts
   vars:
+    devices: "[{% for device in ansible_devices.keys()%}{% if device not in maas_excluded_devices|default([]) %}'{{ device }}',{% endif %}{% endfor %}]"
     check_name: disk_utilisation
     check_details: file={{ check_name }}.py
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
-    alarms:
-      - { 'name': 'percentage_disk_utilisation_sda', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["disk_utilisation_sda"] >= 90.0) { return new AlarmStatus(WARNING, "Disk utilisation for sda >= 90%"); }' }
-      - { 'name': 'percentage_disk_utilisation_sdb', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["disk_utilisation_sdb"] >= 90.0) { return new AlarmStatus(WARNING, "Disk utilisation for sdb >= 90%"); }' }
-      - { 'name': 'percentage_disk_utilisation_sdc', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric["disk_utilisation_sdc"] >= 90.0) { return new AlarmStatus(WARNING, "Disk utilisation for sdc >= 90%"); }' }
+    # TODO (mattt): refactor this code so we can properly create dynamic alarms
+    #               without using jinja
+    alarms: "[{% for device in devices %}{ 'name': 'percentage_disk_utilisation_{{ device }}', 'criteria': ':set consecutiveCount={{ maas_alarm_local_consecutive_count }} if (metric[\"disk_utilisation_{{ device }}\"] >= 90.0) { return new AlarmStatus(WARNING, \"Disk utilisation for {{ device }} >= 90%\"); }' },{% endfor %}]"
   user: root
   roles:
     - maas_local


### PR DESCRIPTION
Currently, we create checks for {sda,sdb,sdc}, but not every server will
have these devices.  This commit loops over {{ ansible_devices }}
instead so we create an alarm for any discovered device.

Additionally, if a user variable called maas_excluded_devices exists,
we'll skip over those devices when creating alarms.

(cherry picked from commit 787599a1d05a2d421a5aa93e285988e88b59919f)

Closes issue #430
