### PR TITLE
Do now recursively chown {{ install_lib_dir }}

### DIFF
--- a/rpc_deployment/inventory/group_vars/horizon.yml
+++ b/rpc_deployment/inventory/group_vars/horizon.yml
@@ -50,7 +50,6 @@ install_lib_dir: /usr/local/lib/python2.7/dist-packages
 
 container_directories:
   - "/etc/horizon"
-  - "{{ install_lib_dir }}"
 
 service_pip_dependencies:
   - MySQL-python


### PR DESCRIPTION
Currently, we recursively chown /usr/local/lib/python2.7/dist-packages
to www-data:www-data.  This should be unnecessary as we can (and do)
chown individual directories in the horizon specific roles.

(cherry picked from commit a63180ae1ffa4e19a854e2aced53567e76e58cb9)

Closes issue #367
