### PR TITLE
Run glance-manage as {{ system_user }}

### DIFF
--- a/rpc_deployment/roles/glance_setup/tasks/main.yml
+++ b/rpc_deployment/roles/glance_setup/tasks/main.yml
@@ -15,3 +15,5 @@
 
 - name: Perform a Glance DB sync
   command: glance-manage db_sync
+  sudo: yes
+  sudo_user: "{{ system_user }}"


### PR DESCRIPTION
Currently this task is run as root, however as glance has no separate
glance-manage.log file, this _could_ result in
/var/log/glance/glance-api.log being owned by root.  This change causes
glance-manage to be run as {{ system_user }} which should eliminate
this from happening.

(cherry picked from commit 17ae7f3b0976e8fe19aade8725021e468b3616d0)

Closes issue #497
