### PR TITLE
Ensure OpenStack commands are run as correct user

### DIFF
--- a/rpc_deployment/playbooks/openstack/nova-compute-keys.yml
+++ b/rpc_deployment/playbooks/openstack/nova-compute-keys.yml
@@ -17,6 +17,8 @@
   user: root
   roles:
     - nova_compute_sshkey_create
+  vars_files:
+    - inventory/group_vars/nova_all.yml
 
 - hosts: nova_compute[0]
   user: root

--- a/rpc_deployment/playbooks/openstack/nova-compute.yml
+++ b/rpc_deployment/playbooks/openstack/nova-compute.yml
@@ -13,11 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: nova_compute[0]
-  user: root
-  roles:
-    - nova_compute_sshkey_create
-
 - hosts: nova_compute
   user: root
   roles:

--- a/rpc_deployment/roles/cinder_setup/tasks/main.yml
+++ b/rpc_deployment/roles/cinder_setup/tasks/main.yml
@@ -15,3 +15,5 @@
 
 - name: Perform a Cinder DB sync
   command: cinder-manage db sync
+  sudo: yes
+  sudo_user: "{{ system_user }}"

--- a/rpc_deployment/roles/heat_setup/tasks/main.yml
+++ b/rpc_deployment/roles/heat_setup/tasks/main.yml
@@ -15,3 +15,5 @@
 
 - name: Perform a Heat DB sync
   command: heat-manage db_sync
+  sudo: yes
+  sudo_user: "{{ system_user }}"

--- a/rpc_deployment/roles/horizon_setup/tasks/main.yml
+++ b/rpc_deployment/roles/horizon_setup/tasks/main.yml
@@ -13,5 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Unlike the 'db sync' command run in other projects, we do not run this under
+# horizon's {{ system_user }} as horizon is run through Apache and logs are
+# written to as root
 - name: Run syncdb
   command: horizon-manage.py syncdb --noinput

--- a/rpc_deployment/roles/keystone_setup/tasks/keystone_token_cron.yml
+++ b/rpc_deployment/roles/keystone_setup/tasks/keystone_token_cron.yml
@@ -18,4 +18,4 @@
     name: "Clear out stale keystone tokens"
     minute: 0
     job: "keystone-manage token_flush"
-    user: keystone
+    user: "{{ system_user }}"

--- a/rpc_deployment/roles/neutron_setup/tasks/main.yml
+++ b/rpc_deployment/roles/neutron_setup/tasks/main.yml
@@ -18,6 +18,8 @@
     neutron-db-manage --config-file {{ neutron_config }}
                       --config-file {{ neutron_plugin }}
                       upgrade {{ neutron_revision }}
+  sudo: yes
+  sudo_user: "{{ system_user }}"
   tags:
     - neutron_upgrade
 
@@ -25,6 +27,8 @@
   shell: "neutron-db-manage history | grep -w 'Revision ID: {{ neutron_revision }}'"
   register: neutron_dbmanage
   ignore_errors: True
+  sudo: yes
+  sudo_user: "{{ system_user }}"
   tags:
     - neutron_stamp
 
@@ -34,5 +38,7 @@
                       --config-file {{ neutron_plugin }} 
                       stamp {{ neutron_revision }}
   when: neutron_dbmanage.rc != 0
+  sudo: yes
+  sudo_user: "{{ system_user }}"
   tags:
     - neutron_stamp

--- a/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
+++ b/rpc_deployment/roles/nova_compute_sshkey_create/tasks/main.yml
@@ -36,7 +36,9 @@
     - "/var/lib/nova/.ssh/id_rsa.pub"
 
 - name: Create the nova SSH key if it doesnt exist
-  shell: su - nova -c 'ssh-keygen -f /var/lib/nova/.ssh/id_rsa -t rsa -q -N ""'
+  command: ssh-keygen -f /var/lib/nova/.ssh/id_rsa -t rsa -q -N ""
+  sudo: yes
+  sudo_user: "{{ system_user }}"
 
 - name: Create empty 'authorized_keys' file
   file: path="/var/lib/nova/.ssh/authorized_keys" state="touch"
@@ -44,8 +46,8 @@
 - name: Change permissions on the generated keys
   file:
     path: "{{ item.path }}"
-    group: "nova"
-    owner: "nova"
+    group: "{{ system_user }}"
+    owner: "{{ system_user }}"
     mode: "{{ item.mode }}"
   with_items:
     - { path: "/var/lib/nova/.ssh/authorized_keys", mode: "0700" }

--- a/rpc_deployment/roles/nova_setup/tasks/main.yml
+++ b/rpc_deployment/roles/nova_setup/tasks/main.yml
@@ -15,3 +15,5 @@
 
 - name: Perform a Nova DB sync
   command: nova-manage db sync
+  sudo: yes
+  sudo_user: "{{ system_user }}"


### PR DESCRIPTION
Currently, a number of OpenStack commands are run as root (namely,
those management related commands to handle db creation/migrations).
This change updates these affected tasks to use sudo to run the commands
as the correct user.

We also make a few other minor changes, namely:
- updating some hard-coded users to reflect {{ system_user }} instead
- removing nova_compute_sshkey_create role from nova-compute.yml
  playbook (this role is already listed in nova-compute-keys.yml, which
  is included in nova-all.yml)
- adding a vars_files to nova-compute-keys.yml so we can reference
  {{ system_user }} instead of the hard-coded nova user
- updating the 'Create the nova SSH key if it doesnt exist' task to use
  sudo rather than su

(cherry picked from commit a4431dfba6094cf232ca866953249156022f7d4a)

Closes issue #504
