### PR TITLE
point repo_url at rpc.cloudnull.io

### DIFF
--- a/rpc_deployment/inventory/group_vars/all.yml
+++ b/rpc_deployment/inventory/group_vars/all.yml
@@ -40,7 +40,7 @@ external_vip_address: "{{ external_lb_vip_address }}"
 
 
 ## URL for the frozen rpc repo
-rpc_repo_url: "http://rpc-slushee.rackspace.com"
+rpc_repo_url: "http://rpc.cloudnull.io"
 rpc_release: "10.0.0rc4"
 
 ## GPG Keys


### PR DESCRIPTION
Note this will need to change to http://mirror.rackspace.com/rackspaceprivatecloud/ in the final release
