### PR TITLE
Add /var/cache/swift as a directory

### DIFF
--- a/rpc_deployment/inventory/group_vars/swift_all.yml
+++ b/rpc_deployment/inventory/group_vars/swift_all.yml
@@ -66,6 +66,7 @@ service_names:
 container_directories:
   - /var/log/swift
   - /var/lock/swift
+  - /var/cache/swift
   - /etc/swift
   - /etc/swift/rings/
   - /etc/swift/object-server


### PR DESCRIPTION
- Servers require access to /var/cache/swift
- Directory will now exist and be owned by swift

Fixes #545
