### PR TITLE
Add 'devices' option to the replicator conf file

### DIFF
--- a/rpc_deployment/roles/swift_account/templates/account-server-replicator.conf.j2
+++ b/rpc_deployment/roles/swift_account/templates/account-server-replicator.conf.j2
@@ -2,6 +2,7 @@
 {% set repl_bridge = 'ansible_' + swift.replication_network|replace('-', '_') %}
 bind_ip = {{ hostvars[inventory_hostname][repl_bridge]['ipv4']['address'] }}
 bind_port = {{ swift_account_port }}
+devices = {{ swift_vars.mount_point | default(swift.mount_point) }}
 workers = 2
 
 [pipeline:main]

--- a/rpc_deployment/roles/swift_container/templates/container-server-replicator.conf.j2
+++ b/rpc_deployment/roles/swift_container/templates/container-server-replicator.conf.j2
@@ -2,6 +2,7 @@
 {% set repl_bridge = 'ansible_' + swift.replication_network|replace('-', '_') %}
 bind_ip = {{ hostvars[inventory_hostname][repl_bridge]['ipv4']['address'] }}
 bind_port = {{ swift_container_port }}
+devices = {{ swift_vars.mount_point | default(swift.mount_point) }}
 workers = 2
 
 [pipeline:main]

--- a/rpc_deployment/roles/swift_object/templates/object-server-replicator.conf.j2
+++ b/rpc_deployment/roles/swift_object/templates/object-server-replicator.conf.j2
@@ -2,6 +2,7 @@
 {% set repl_bridge = 'ansible_' + swift.replication_network|replace('-', '_') %}
 bind_ip = {{ hostvars[inventory_hostname][repl_bridge]['ipv4']['address'] }}
 bind_port = {{ swift_object_port }}
+devices = {{ swift_vars.mount_point | default(swift.mount_point) }}
 workers = 2
 
 [pipeline:main]


### PR DESCRIPTION
- Fixes issue where replicators are ignoring drives
- devices option needs to be present in both confs.

Fixes #548
