### PR TITLE
Adjust /var/log/swift creation for proxy-server

### DIFF
--- a/rpc_deployment/inventory/group_vars/swift_all.yml
+++ b/rpc_deployment/inventory/group_vars/swift_all.yml
@@ -64,7 +64,6 @@ service_names:
   - swift-proxy
 
 container_directories:
-  - /var/log/swift
   - /var/lock/swift
   - /etc/swift
   - /etc/swift/rings/


### PR DESCRIPTION
- log dir needs to be owned by syslog instead of swift
- Remove from group_vars
- Dir is created by the log_setup task in the swift_common role

Fixes #552
