### PR TITLE
BACKPORT - #487 Allow NFS mounts within the cinder-volumes container

### DIFF
--- a/rpc_deployment/roles/lxc_common/files/lxc-openstack
+++ b/rpc_deployment/roles/lxc_common/files/lxc-openstack
@@ -15,6 +15,7 @@ profile lxc-openstack flags=(attach_disconnected,mediate_deleted) {
   mount fstype=vfat* -> /**,
   mount fstype=fuseblk -> /**,
   mount fstype=nbd* -> /**,
+  mount fstype=nfs* -> /var/lib/cinder/mnt/**,
   mount fstype=devpts,
   
 # allow System access.


### PR DESCRIPTION
Backport from master for aa profile update.

Cherry Pick: ebcab7c
Related issue: #487
