### PR TITLE
NFS client configuration for cinder (fixes #506)

### DIFF
--- a/etc/rpc_deploy/rpc_user_config.yml.example
+++ b/etc/rpc_deploy/rpc_user_config.yml.example
@@ -188,6 +188,10 @@ storage_hosts:
           netapp_password: "{{ cinder_netapp_password }}"
           volume_driver: cinder.volume.drivers.netapp.common.NetAppDriver
           volume_backend_name: NETAPP_iSCSI
+      nfs_client:
+        nfs_shares_config: /etc/cinder/nfs_shares
+        shares:
+          - { ip: "{{ cinder_netapp_hostname }}", share: "/vol/cinder" }
 
 # User defined Logging Hosts, this should be a required group
 log_hosts:

--- a/rpc_deployment/roles/cinder_common/templates/cinder.conf
+++ b/rpc_deployment/roles/cinder_common/templates/cinder.conf
@@ -52,6 +52,9 @@ enabled_backends={% for backend in cinder_backends|dictsort %}{{ backend.0 }}{% 
 {% for key, value in backend_section.1.items() %}
 {{ key }}={{ value }}
 {% endfor %}
+{% if nfs_client is defined %}
+nfs_shares_config={{ nfs_client.nfs_shares_config }}
+{% endif %}
 
 {% endfor %}
 {% endif %}

--- a/rpc_deployment/roles/nfs_client/tasks/main.yml
+++ b/rpc_deployment/roles/nfs_client/tasks/main.yml
@@ -13,20 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: cinder_volume
-  user: root
-  roles:
-    - container_common
-    - container_extra_setup
-    - cinder_common
-    - cinder_volume
-    - cinder_device_add
-    - cinder_backend_types
-    - nfs_client
-    - init_script
-  vars_files:
-    - vars/config_vars/container_config_cinder_volume.yml
-    - vars/openstack_service_vars/cinder_volume.yml
-    - vars/repo_packages/cinder.yml
-  handlers:
-    - include: handlers/services.yml
+- name: Create nfs_shares file
+  template:
+    src=nfs_shares.j2
+    dest="{{ nfs_client.nfs_shares_config }}"
+  when: nfs_client is defined

--- a/rpc_deployment/roles/nfs_client/templates/nfs_shares.j2
+++ b/rpc_deployment/roles/nfs_client/templates/nfs_shares.j2
@@ -1,0 +1,3 @@
+{% for share in nfs_client.shares %}
+{{ share.ip }}: {{ share.share }}
+{% endfor %}

--- a/rpc_deployment/vars/repo_packages/cinder.yml
+++ b/rpc_deployment/vars/repo_packages/cinder.yml
@@ -44,3 +44,4 @@ container_packages:
   - tgt
   - parted
   - qemu-utils
+  - nfs-common


### PR DESCRIPTION
Adds the NFS client configuration in the cinder_volume hosts, which is necessary when using a netapp backend over NFS.
