### PR TITLE
missing .ssh directory

### DIFF
--- a/scripts/cloudserver-aio.sh
+++ b/scripts/cloudserver-aio.sh
@@ -102,6 +102,10 @@ if [ -f "/opt/swap.sh" ];then
 fi
 
 # Make the system key used for bootstrapping self
+if [ ! -d /root/.ssh ];then
+    mkdir -p /root/.ssh
+    chmod 700 /root/.ssh
+fi
 pushd /root/.ssh/
   if [ ! -f "id_rsa" ];then
       key_create


### PR DESCRIPTION
Added a check to see if /root/.ssh exists prior to pushd (also creates dir with correct perms if it doesn't).
