### PR TITLE
fixed generator type assumption error

### DIFF
--- a/rpc_deployment/inventory/dynamic_inventory.py
+++ b/rpc_deployment/inventory/dynamic_inventory.py
@@ -260,10 +260,11 @@ def _append_to_host_groups(inventory, container_type, assignment, host_type,
                         limit = None
                         # If a limit is set use the limit string as a filter
                         # for the container name and see if it matches.
-                        if 'limit_container_types' in options:
-                            limit = options.pop(
-                                'limit_container_types', None
-                            )
+                        if isinstance(options, (str, dict, list)):
+                            if 'limit_container_types' in options:
+                                limit = options.pop(
+                                    'limit_container_types', None
+                                )
 
                         if limit is None or limit in container:
                             hdata[_keys] = options


### PR DESCRIPTION
This PR adds a type check to ensure that the value of "options" is iterable.

Fixes Issue: https://github.com/rcbops/ansible-lxc-rpc/issues/564
