### PR TITLE
Increase tempest timeouts for Cinder tests

### DIFF
--- a/rpc_deployment/roles/tempest/templates/tempest.conf.j2
+++ b/rpc_deployment/roles/tempest/templates/tempest.conf.j2
@@ -16,7 +16,7 @@ s3_materials_path = /opt/stack/devstack/files/images/s3-materials/cirros-0.3.2
 s3_url = http://134.213.136.181:3333
 ec2_url = http://134.213.136.181:8773/services/Cloud
 http_socket_timeout = 30
-build_timeout = 196
+build_timeout = 600
 
 [cli]
 cli_dir = /usr/local/bin
@@ -37,7 +37,7 @@ ip_version_for_ssh = 4
 network_for_ssh = private
 ssh_user = cirros
 allow_tenant_isolation = True
-build_timeout = 196
+build_timeout = 600
 
 [compute-admin]
 tenant_name = {{ auth_admin_tenant }}
@@ -139,7 +139,7 @@ too_slow_to_test = False
 
 
 [volume]
-build_timeout = 196
+build_timeout = 600
 
 
 [volume-feature-enabled]


### PR DESCRIPTION
Jenkins is configured to use pub swift as a glance backend, some
glance operations take longer than the default timeout.

This patch increases the relevant timeouts. These timeouts were hit
during the cinder tests as cinder creates images from volumes, which
glance then stores as objects in swift. (cinder -> glance -> pub swift).

+100 Ae.

The compute timeout needs to be raised because the tempest image client
doesn't have its own timeout so it inherits the compute timeout.

There is a review for adding an image specific timeout but that will
probably be rejected: https://review.openstack.org/#/c/135911/

Also cinder api extensions are disabled. Lets get the core working
first.

Related: https://github.com/rcbops/ansible-lxc-rpc/issues/472
