### PR TITLE
Bump python-saharaclient version

### DIFF
--- a/rpc_deployment/vars/repo_packages/python_saharaclient.yml
+++ b/rpc_deployment/vars/repo_packages/python_saharaclient.yml
@@ -19,6 +19,6 @@ repo_path: "{{ pip_wheel_name }}_{{ git_install_branch | replace('/', '_') }}"
 git_repo: https://github.com/openstack/python-saharaclient
 git_fallback_repo: https://git.openstack.org/openstack/python-saharaclient
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: 0.7.4
+git_install_branch: 0.7.5
 
 pip_wheel_name: python-saharaclient


### PR DESCRIPTION
python-saharaclient>=0.7.5 is required by tempest, so we must make that
version available. AFAIK we're not actually using it for anything, so
increasing the version shouldn't cause a problem.

Related: #597
(cherry picked from commit 18bc25166360568b54744d8b1002914d75d1cca6)
