### PR TITLE
Freeze tempest sha in proposed/juno

### DIFF
--- a/rpc_deployment/vars/repo_packages/tempest.yml
+++ b/rpc_deployment/vars/repo_packages/tempest.yml
@@ -21,7 +21,7 @@ repo_path: "{{ repo_package_name }}_{{ git_install_branch | replace('/', '_') }}
 git_repo: https://github.com/openstack/tempest
 git_fallback_repo: https://git.openstack.org/openstack/tempest
 git_dest: "/opt/{{ repo_path }}"
-git_install_branch: master
+git_install_branch: 9981e16846fdfbae294e31d565e215ad4f0a70bd
 
 pip_wheel_name: tempest
 


### PR DESCRIPTION
We recently had a problem where tempest requirements changed and caused
tempest installs to fail. This branch fixes the SHA of tempest that we
install so that we aren't chasing a moving target in a stable branch.

Related: #597
