### PR TITLE
ensure x-compute-request-id is added to response headers from nova v2 api

### DIFF
--- a/rpc_deployment/roles/nova_common/templates/api-paste.ini
+++ b/rpc_deployment/roles/nova_common/templates/api-paste.ini
@@ -65,14 +65,20 @@ use = call:nova.api.openstack.urlmap:urlmap_factory
 
 [composite:openstack_compute_api_v2]
 use = call:nova.api.auth:pipeline_factory
-noauth = faultwrap sizelimit noauth ratelimit osapi_compute_app_v2
-keystone = faultwrap sizelimit authtoken keystonecontext ratelimit osapi_compute_app_v2
-keystone_nolimit = faultwrap sizelimit authtoken keystonecontext osapi_compute_app_v2
+noauth = compute_req_id faultwrap sizelimit noauth ratelimit osapi_compute_app_v2
+keystone = compute_req_id faultwrap sizelimit authtoken keystonecontext ratelimit osapi_compute_app_v2
+keystone_nolimit = compute_req_id faultwrap sizelimit authtoken keystonecontext osapi_compute_app_v2
 
 [composite:openstack_compute_api_v3]
 use = call:nova.api.auth:pipeline_factory_v3
-noauth = faultwrap sizelimit noauth_v3 osapi_compute_app_v3
-keystone = faultwrap sizelimit authtoken keystonecontext osapi_compute_app_v3
+noauth = request_id faultwrap sizelimit noauth_v3 osapi_compute_app_v3
+keystone = request_id faultwrap sizelimit authtoken keystonecontext osapi_compute_app_v3
+
+[filter:request_id]
+paste.filter_factory = nova.openstack.common.middleware.request_id:RequestIdMiddleware.factory
+
+[filter:compute_req_id]
+paste.filter_factory = nova.api.compute_req_id:ComputeReqIdMiddleware.factory
 
 [filter:faultwrap]
 paste.filter_factory = nova.api.openstack:FaultWrapper.factory


### PR DESCRIPTION
In commit:

https://github.com/openstack/nova/commit/49d83e356afd6197fc95277f0d18723bdfa11652

The addition of the x-compute-request-id to the response headers was moved out to a separate module.

In order to ensure that it gets added to response headers, some additional options are required in nova api-paste.ini

(cherry picked from commit 31f18364bbd309f060b097f63b86787d0abcfed8)

Issue: #576 
