### PR TITLE
Install lxml dependency

### DIFF
--- a/rpc_deployment/vars/repo_packages/keystone.yml
+++ b/rpc_deployment/vars/repo_packages/keystone.yml
@@ -48,3 +48,4 @@ service_pip_dependencies:
   - python-memcached
   - python-keystoneclient
   - keystonemiddleware
+  - lxml


### PR DESCRIPTION
Running tempest smoke tests fail on all the XML tests due to lxml not
being installed in keystone containers.  The lxml package is no longer
a hard dependency since lxml is only required when using the (optional)
XmlBodyMiddleware middleware.

Ideally we'd want to remove XmlBodyMiddleware middleware since it's
being removed in Kilo, however I have not seen an option to disable all
the XML tests in tempest.

(cherry picked from commit 0c5a8297e7775bc23408297a93bcca0f3acdf800)
