### PR TITLE
BACKPORT - stable/icehouse - Add retries for cinder get test

### DIFF
--- a/rpc_deployment/roles/cinder_backend_types/tasks/main.yml
+++ b/rpc_deployment/roles/cinder_backend_types/tasks/main.yml
@@ -26,6 +26,9 @@
     return_content=true
   register: cinder_get
   failed_when: "'CURRENT' not in cinder_get.content"
+  until: cinder_get|success
+  retries: 20
+  delay: 2
 
 - name: Add in cinder devices types
   shell: |


### PR DESCRIPTION
This fails as the volume service takes >10 seconds to start.
Adding retries is better than increasing the delay as it prevents
unnecesary waiting.

Closes #353
Cherry-pick from 4fdd8571e5d2e66179339a6800f8519449e3ff67
