### PR TITLE
BACKPORT - stable/icehouse - Added nova console variable

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -138,6 +138,10 @@ nova_service_password:
 nova_v3_service_password:
 nova_s3_service_password:
 
+# Uncomment "nova_console_endpoint" to define a specific nova console URI or 
+# IP address this will construct the specific proxy endpoint for the console.
+# nova_console_endpoint: console.company_domain.name
+
 
 ## RPC Support
 rpc_support_holland_password:

--- a/rpc_deployment/vars/openstack_service_vars/nova_spice_console_endpoint.yml
+++ b/rpc_deployment/vars/openstack_service_vars/nova_spice_console_endpoint.yml
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-nova_html5proxy_base_url: "http://{{ external_vip_address }}:6082/spice_auto.html"
+nova_html5proxy_base_url: "http://{{ nova_console_endpoint|default(external_vip_address) }}:6082/spice_auto.html"
 nova_console_keymap: en-us
 nova_console_agent_enabled: True


### PR DESCRIPTION
Added specific console variable to the config and provided and example of how to use the new variable.
The variable is "nova_console_endpoint" variable

Resolves Issue #409
Cherry pick from f047da828a4b4c3bcb3c5ac3f992392ef9426c76
