### PR TITLE
BACKPORT - proposed/juno - adjust default cpu and ram allocation ratios

### DIFF
--- a/etc/rpc_deploy/user_variables.yml
+++ b/etc/rpc_deploy/user_variables.yml
@@ -132,6 +132,8 @@ neutron_service_password:
 # This defaults to KVM, if you are deploying on a host that is not KVM capable
 # change this to your hypervisor type: IE "qemu", "lxc".
 # nova_virt_type: kvm
+# nova_cpu_allocation_ratio: 2.0
+# nova_ram_allocation_ratio: 1.0
 nova_container_mysql_password:
 nova_metadata_proxy_secret:
 nova_ec2_service_password:

--- a/rpc_deployment/inventory/group_vars/nova_all.yml
+++ b/rpc_deployment/inventory/group_vars/nova_all.yml
@@ -68,11 +68,11 @@ nova_compute_driver: libvirt.LibvirtDriver
 nova_max_age: 0
 
 # Nova Scheduler
-nova_cpu_allocation_ratio: 5.0
+nova_cpu_allocation_ratio: 2.0
 nova_disk_allocation_ratio: 1.0
 nova_max_instances_per_host: 50
 nova_max_io_ops_per_host: 10
-nova_ram_allocation_ratio: 1.5
+nova_ram_allocation_ratio: 1.0
 nova_ram_weight_multiplier: 5.0
 nova_reserved_host_disk_mb: 2048
 nova_reserved_host_memory_mb: 2048


### PR DESCRIPTION
As per support discussion, modify:

nova_cpu_allocation_ratio = 2.0
nova_ram_allocation_ratio = 1.0

Resolves issue: https://github.com/rcbops/ansible-lxc-rpc/pull/579
Cherry Pick from e16c0939ad0f1d6f9da3275f1c8ad5d5db211ab6
