### PR TITLE
Adjust default swift-proxy port to OpenStack default 8080

### DIFF
--- a/rpc_deployment/inventory/group_vars/swift_all.yml
+++ b/rpc_deployment/inventory/group_vars/swift_all.yml
@@ -31,7 +31,7 @@ container_lvm_fstype: ext4
 container_lvm_fssize: 5GB
 
 # Swift default ports
-swift_proxy_port: "8888"
+swift_proxy_port: "8080"
 swift_object_port: "6000"
 swift_container_port: "6001"
 swift_account_port: "6002"

--- a/rpc_deployment/playbooks/monitoring/swift_maas.yml
+++ b/rpc_deployment/playbooks/monitoring/swift_maas.yml
@@ -53,7 +53,7 @@
 - hosts: swift_proxy
   vars:
     check_name: swift_proxy_server_check
-    check_details: file=service_api_local_check.py,args=swift_proxy_server,args=--path,args=/healtcheck,args={{ ansible_ssh_host }},args=8888
+    check_details: file=service_api_local_check.py,args=swift_proxy_server,args=--path,args=/healtcheck,args={{ ansible_ssh_host }},args=8080
     check_period: "{{ maas_check_period }}"
     check_timeout: "{{ maas_check_timeout }}"
     alarms:
@@ -78,7 +78,7 @@
     notification_plan: "{{ maas_notification_plan }}"
     scheme: "{{ maas_swift_proxy_scheme | default(maas_scheme)}}"
     ip_address: "{{ external_vip_address }}"
-    port: 8888
+    port: 8080
     path: "/healthcheck"
     url: "{{ scheme }}://{{ ip_address }}:{{ port }}{{ path }}"
     alarm_name: lb_api_alarm_swift_proxy

--- a/rpc_deployment/vars/config_vars/haproxy_config.yml
+++ b/rpc_deployment/vars/config_vars/haproxy_config.yml
@@ -155,7 +155,7 @@ haproxy_config:
   - service:
       hap_service_name: kibana
       hap_backend_nodes: "{{ [groups['kibana'][0]] }}"
-      hap_port: 8080
+      hap_port: 8888
       hap_backend_port: 80
       hap_balance_type: http
       hap_backend_alg: source
@@ -174,5 +174,5 @@ haproxy_config:
   - service:
       hap_service_name: swift_proxy
       hap_backend_nodes: "{{ groups['swift_proxy'] }}"
-      hap_port: 8888
+      hap_port: 8080
       hap_balance_type: http


### PR DESCRIPTION
- Adjust proxy-server to use port 8080 by default
- Adjust haproxy plays to use the appropriate port for swift-proxy
- Move kibana haproxy port from 8080 to 8888
- Adjust MaaS plays to use port 8080 for swift-proxy monitoring

Fixes #609
