### PR TITLE
Add python-swiftclient to swift hosts

### DIFF
--- a/rpc_deployment/vars/repo_packages/swift.yml
+++ b/rpc_deployment/vars/repo_packages/swift.yml
@@ -32,6 +32,7 @@ service_pip_dependencies:
   - pycrypto
   - python-cinderclient
   - python-keystoneclient
+  - python-swiftclient
   - keystonemiddleware
 
 container_packages:


### PR DESCRIPTION
- Add python-swiftclient to repo_packages list
- Allows the use of swift client on swift hosts

Fixes #596
