### PR TITLE
Add swift_hash_path to pw-token-gen.py

### DIFF
--- a/scripts/pw-token-gen.py
+++ b/scripts/pw-token-gen.py
@@ -170,6 +170,9 @@ def main():
             elif entry.endswith('key'):
                 changed = True
                 user_vars[entry] = generator.generator(pw_type='key')
+            elif entry.startswith('swift_hash_path'):
+                changed = True
+                user_vars[entry] = generator.generator(pw_type='key')
 
     # If changed is set to True, this will archive the old passwords
     if changed is True:


### PR DESCRIPTION
- Set swift_hash_path vars to be setup as keys
- Allows these vars to be auto generated

Fixes #611
