### PR TITLE
Stop swift logs from going into /var/log/syslog

### DIFF
--- a/rpc_deployment/playbooks/openstack/swift-common.yml
+++ b/rpc_deployment/playbooks/openstack/swift-common.yml
@@ -22,5 +22,6 @@
     - openstack_common
     - openstack_openrc
     - galera_client_cnf
+    - rsyslog
   vars_files:
     - vars/repo_packages/swift.yml

--- a/rpc_deployment/roles/swift_common/tasks/log_setup.yml
+++ b/rpc_deployment/roles/swift_common/tasks/log_setup.yml
@@ -26,6 +26,6 @@
 - name: "Drop swift rsyslog conf"
   template:
     src: "swift-rsyslog.conf.j2"
-    dest: "/etc/rsyslog.d/52-swift.conf"
+    dest: "/etc/rsyslog.d/49-swift.conf"
   notify:
     - restart rsyslog


### PR DESCRIPTION
- Add the rsyslog role to the swift hosts
- Adds local7.none to /var/log/syslog
- Move the swift rsyslog conf to be before the default conf

Fixes #640
