### PR TITLE
Fix location for swift-recon-cron

### DIFF
--- a/rpc_deployment/roles/swift_storage_setup/tasks/swift_recon_cron.yml
+++ b/rpc_deployment/roles/swift_storage_setup/tasks/swift_recon_cron.yml
@@ -13,10 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# We need the location of swift-recon-cron
+- name: "Get location of swift-recon-cron"
+  shell: which swift-recon-cron
+  register: recon_cron_path
+
 - name: "Setup swift-recon-cron cron job"
   cron: >
     name="swift-recon-cron run"
     minute=*/5
     user="swift"
-    job="/usr/bin/swift-recon-cron /etc/swift/object-server/object-server.conf"
+    job="{{ recon_cron_path.stdout }} /etc/swift/object-server/object-server.conf"
     cron_file="swift_recon_cron"


### PR DESCRIPTION
- Perform a which to find where swift-recon-cron is
- Setup the cron job based on this location

Fixes #643
