### PR TITLE
Run horizon-manage.py script as {{ system_user }}

### DIFF
--- a/rpc_deployment/inventory/group_vars/horizon.yml
+++ b/rpc_deployment/inventory/group_vars/horizon.yml
@@ -51,6 +51,8 @@ install_lib_dir: /usr/local/lib/python2.7/dist-packages
 container_directories:
   - "/etc/horizon"
   - "/var/lib/horizon"
+  - "/usr/local/lib/python2.7/dist-packages/static"
+  - "/usr/local/lib/python2.7/dist-packages/openstack_dashboard/local"
 
 horizon_fqdn: "{{ external_vip_address }}"
 horizon_server_name: "{{ container_name }}"

--- a/rpc_deployment/roles/horizon_common/tasks/main.yml
+++ b/rpc_deployment/roles/horizon_common/tasks/main.yml
@@ -13,14 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Add horizon etc dir
-  file:
-    dest: "/etc/horizon"
-    recurse: "yes"
-    owner: "{{ system_user }}"
-    group: "{{ system_group }}"
-    state: "directory"
-
 # The Horizon config files should be replaced for the JUNO release
 # juno_revision: true
 - name: Setup Horizon config(s)
@@ -54,6 +46,8 @@
 # /opt/horizon/lib/python2.7/site-packages/manage.py
 - name: Collect and compress static files
   command: "{{ item }}"
+  sudo: yes
+  sudo_user: "{{ system_user }}"
   with_items:
     - horizon-manage.py collectstatic --noinput
     - horizon-manage.py compress --force
@@ -67,13 +61,3 @@
     state: "link"
   with_items:
     - { src: "/etc/horizon/local_settings.py", dest: "{{ install_lib_dir }}/openstack_dashboard/local/local_settings.py" }
-
-- name: Set horizon permissions
-  file:
-    dest: "{{ item }}"
-    recurse: "yes"
-    owner: "{{ system_user }}"
-    group: "{{ system_group }}"
-    state: "directory"
-  with_items:
-    - "{{ install_lib_dir }}/static"

--- a/rpc_deployment/roles/horizon_setup/tasks/main.yml
+++ b/rpc_deployment/roles/horizon_setup/tasks/main.yml
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Unlike the 'db sync' command run in other projects, we do not run this under
-# horizon's {{ system_user }} as horizon is run through Apache and logs are
-# written to as root
+# This will create /var/lib/horizon/.secret_key_store, which needs to be owned
+# by {{ system_user }}, otherwise horizon logins will fail
 - name: Run syncdb
   command: horizon-manage.py syncdb --noinput
+  sudo: yes
+  sudo_user: "{{ system_user }}"


### PR DESCRIPTION
Currently, we seem to always have 1/3 horizon nodes where
/var/lib/horizon/.secret_key_store is owned by root which breaks
horizon logins.  This appears to be a result of running
horizon-manage.py syncdb as root (which only happens on 1/3 nodes).
This change moves all horizon-manage.py commands to run as
{{ system_user }}, which requires us to also pre-create some dirs
owned by {{ system_user }} by adding them to container_directories so
that the horizon-manage.py commands will all complete successfully.

Lastly, we remove the creation of /etc/horizon and the chown of files
in {{ install_lib_dir }}/static in heat_common role since those have
been added to container_directories.

Closes issue #650
