### PR TITLE
Enable user to specify cinder volume container size

### DIFF
--- a/etc/rpc_deploy/rpc_user_config.yml
+++ b/etc/rpc_deploy/rpc_user_config.yml
@@ -39,6 +39,10 @@ used_ips:
 # override from within the rpc_deploy configuration file. Anything 
 # specified here will take precedence over anything else any where.
 global_overrides:
+  # Size of cinder volumes container. Default is 5GB.
+  # Space must be added for cinder to have enough space to convert images.
+  # For example, to be able to convert 100GB images, set this value to 105.
+  #cinder_volume_lv_size_gb: 105GB
   # Internal Management vip address
   internal_lb_vip_address: 172.29.236.1
   # External DMZ VIP address

--- a/rpc_deployment/inventory/group_vars/cinder_volume.yml
+++ b/rpc_deployment/inventory/group_vars/cinder_volume.yml
@@ -1,0 +1,35 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The variables file used by the playbooks in the Cinder-api group.
+# These don't have to be explicitly imported by vars_files: they are autopopulated.
+
+
+# Note, most cinder settings sare set in cinder_all,
+# this file is just to override the lvm size for the volumes container.
+
+# The volumes container needs a larger FS as it must have tmp space for
+# converting glnace imges to volumes.
+# https://github.com/rcbops/ansible-lxc-rpc/issues/166
+
+# Default is 5GB (same as other containers).
+# Space must be added for cinder image conversion to work.
+# For example, to be able to convert 100GB images, set this to 105GB.
+cinder_volume_lv_size_gb: 5GB
+
+# only used when the lxc vg is present on the target
+container_lvm_fssize: "{{cinder_volume_lv_size_gb}}"
+
+

--- a/rpc_deployment/playbooks/setup/build-containers.yml
+++ b/rpc_deployment/playbooks/setup/build-containers.yml
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- hosts: "{{ host_group|default('hosts') }}"
+- hosts: "{{ host_group|default('all_containers') }}"
+  gather_facts: False
   user: root
   roles:
     - container_create
-  vars:
-    default_container_groups: "{{ hostvars[inventory_hostname]['container_types'] }}"
-    container_groups: "{{ groups[container_group|default(default_container_groups)] | default('') }}"
 
 - include: containers-setup.yml

--- a/rpc_deployment/roles/container_create/tasks/container_create.yml
+++ b/rpc_deployment/roles/container_create/tasks/container_create.yml
@@ -20,39 +20,41 @@
     (which vgs > /dev/null && vgs | grep -o "lxc") || false
   register: vg_result
   ignore_errors: True
+  delegate_to: "{{ physical_host }}"
 
 - name: Create Container Local
   lxc: >
-    name={{ hostvars[item]['container_name'] }}
+    name={{ container_name }}
     template={{ container_template }}
-    config={{ hostvars[item]['container_config'] }}
+    config={{ container_config }}
     command=create
     state=running
     template_options="
       --release {{ container_release }}
     "
   when: vg_result.rc == 1
-  with_items: container_groups
+  delegate_to: "{{ physical_host }}"
 
 - name: Check Container Bridge exists
   file: >
     state=file
     path="/sys/class/net/{{ management_bridge }}/bridge/bridge_id"
+  delegate_to: "{{ physical_host }}"
 
 - name: Create Container LVM
   lxc: >
-    name={{ hostvars[item]['container_name'] }}
+    name={{ container_name }}
     template={{ container_template }}
-    config={{ hostvars[item]['container_config'] }}
+    config={{ container_config }}
     command=create
     state=running
     bdev=lvm
-    lvname={{ hostvars[item]['container_name'] }}
+    lvname={{ container_name }}
     vgname=lxc
-    fstype={{ hostvars[item]['container_lvm_fstype'] }}
-    fssize={{ hostvars[item]['container_lvm_fssize'] }}
+    fstype={{ container_lvm_fstype }}
+    fssize={{ container_lvm_fssize }}
     template_options="
       --release {{ container_release }}
     "
   when: vg_result.rc == 0
-  with_items: container_groups
+  delegate_to: "{{ physical_host }}"

--- a/rpc_deployment/roles/container_create/tasks/main.yml
+++ b/rpc_deployment/roles/container_create/tasks/main.yml
@@ -14,4 +14,3 @@
 # limitations under the License.
 
 - include: container_create.yml
-  when: container_groups|length > 0


### PR DESCRIPTION
Cinder requires temporary working space to convert images. This patch exposes cinder_volume_lv_size_gb to the user config file, so the user can decide how large the cinder volumes container should be based on available space and the size of images that will need to be converted.

cinder_volume_lv_size_gb is used to override container_lvm_fssize in group_vars/cinder_volume. Simple enough but doesn't work because templated variables (or indirect variables) are not expanded when accessed via hostvars[] see: https://github.com/ansible/ansible/issues/7844. In order to work around that, I have eliminated hostvars[] usage from the container creation mechanism. This may have positive speed implications as the limit of container creation parallelism is now forks rather than number of hosts. However it does make this change larger than a small bug fix. 

Also note that this patch makes use of delegate_to, so specific ansible versions must be used to avoid https://github.com/ansible/ansible/issues/8705. Our requirements file currently specifies a version before this bug was introduced. 

There are two commits in this PR as one is the actual bugfix, the other is infrastructure changes required for that bugfix to work. Also only the bugfix may be needed if the upstream bugs are fixed. 

Related: #166
