### PR TITLE
Add OS_ENDPOINT_TYPE to glance module

### DIFF
--- a/rpc_deployment/library/glance
+++ b/rpc_deployment/library/glance
@@ -112,10 +112,11 @@ class ManageGlance(object):
 
     def _init_glance(self):
         """ Create glance client object using token and url from keystone """
+        openrc = self._parse_openrc()
         self.glance = glclient.Client(
             version='1',
             endpoint=self.keystone.service_catalog.url_for(
-                service_type='image'),
+                service_type='image', endpoint_type=openrc['OS_ENDPOINT_TYPE']),
             token=self.keystone.get_token(self.keystone.session))
 
     def route(self):


### PR DESCRIPTION
- Ensure glance client looks for the OS_ENDPOINT_TYPE when connecting

Fixes #671
