### PR TITLE
Add OS_ENDPOINT_TYPE to neutron module

### DIFF
--- a/rpc_deployment/library/neutron
+++ b/rpc_deployment/library/neutron
@@ -88,10 +88,12 @@ class ManageNeutron(object):
 
     def _init_neutron(self):
         """ Create neutron client object using token and url from keystone """
+        openrc = self._parse_openrc()
         self.neutron = nclient.Client(
             '2.0',
             endpoint_url=self.keystone.service_catalog.url_for(
-                service_type='network'),
+                service_type='network',
+                endpoint_type=openrc['OS_ENDPOINT_TYPE']),
             token=self.keystone.get_token(self.keystone.session))
 
     def route(self):


### PR DESCRIPTION
- Ensure neutron client looks for OS_ENDPOINT_TYPE when connecting

Fixes #673
